### PR TITLE
Creating automatic filters

### DIFF
--- a/src/DataProvider/DefaultIndexableDataProvider.php
+++ b/src/DataProvider/DefaultIndexableDataProvider.php
@@ -27,7 +27,7 @@ final class DefaultIndexableDataProvider implements IndexableDataProviderInterfa
         $qb = $this
             ->getManager($entity)
             ->createQueryBuilder()
-            ->select('o.id')
+            ->select('DISTINCT o.id')
             ->from($entity, 'o')
         ;
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -6,12 +6,15 @@ namespace Setono\SyliusMeilisearchPlugin\DependencyInjection;
 
 use Setono\SyliusMeilisearchPlugin\DataProvider\DefaultIndexableDataProvider;
 use Setono\SyliusMeilisearchPlugin\Document\Product;
+use Setono\SyliusMeilisearchPlugin\Event\QueryBuilderForDataProvisionCreated;
+use Setono\SyliusMeilisearchPlugin\Filter\Entity\EntityFilterInterface;
 use Setono\SyliusMeilisearchPlugin\Form\Type\SynonymType;
 use Setono\SyliusMeilisearchPlugin\Indexer\DefaultIndexer;
 use Setono\SyliusMeilisearchPlugin\Model\Synonym;
 use Setono\SyliusMeilisearchPlugin\Repository\SynonymRepository;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Component\Resource\Factory\Factory;
+use Sylius\Component\Resource\Model\ToggleableInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -61,6 +64,16 @@ final class Configuration implements ConfigurationInterface
                                 ->defaultNull()
                                 ->info('If you want to prepend a string to the index name, you can set it here. This can be useful in a development setup where each developer has their own prefix. Notice that the environment is already prefixed by default, so you do not have to prefix that.')
                                 ->cannotBeEmpty()
+                            ->end()
+                            ->arrayNode('default_filters')
+                                ->info(
+                                    sprintf(<<<INFO
+The plugin comes with a few filters out of the box based on the entities you configure. E.g. there is an "enabled" filter if your entity implements the %s.
+You can disable/enable them here. If you want to create your own filters, you can do so by implementing the %s or by listening to the %s event
+INFO, ToggleableInterface::class, EntityFilterInterface::class, QueryBuilderForDataProvisionCreated::class),
+                                )
+                                ->useAttributeAsKey('name')
+                                ->scalarPrototype()->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/EventSubscriber/IndexableDataFilter/AbstractFilter.php
+++ b/src/EventSubscriber/IndexableDataFilter/AbstractFilter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\EventSubscriber\IndexableDataFilter;
+
+use Doctrine\ORM\QueryBuilder;
+use Setono\SyliusMeilisearchPlugin\Event\QueryBuilderForDataProvisionCreated;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+abstract class AbstractFilter implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            QueryBuilderForDataProvisionCreated::class => 'filter',
+        ];
+    }
+
+    abstract public function filter(QueryBuilderForDataProvisionCreated $event): void;
+
+    protected static function getRootAlias(QueryBuilder $qb): string
+    {
+        $rootAliases = $qb->getRootAliases();
+
+        return reset($rootAliases);
+    }
+}

--- a/src/EventSubscriber/IndexableDataFilter/ChannelsAwareFilter.php
+++ b/src/EventSubscriber/IndexableDataFilter/ChannelsAwareFilter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\EventSubscriber\IndexableDataFilter;
+
+use Setono\SyliusMeilisearchPlugin\Event\QueryBuilderForDataProvisionCreated;
+use Sylius\Component\Channel\Model\ChannelsAwareInterface;
+
+final class ChannelsAwareFilter extends AbstractFilter
+{
+    public function __construct(private readonly string $index)
+    {
+    }
+
+    public function filter(QueryBuilderForDataProvisionCreated $event): void
+    {
+        if ($event->index->name !== $this->index) {
+            return;
+        }
+
+        if (is_a($event->entity, ChannelsAwareInterface::class, true)) {
+            // At this point we cannot filter based on the channel because it's not available,
+            // but we can filter out entities that are not assigned to any channel
+            $event->qb->andWhere(sprintf('SIZE(%s.channels) > 0', self::getRootAlias($event->qb)));
+        }
+    }
+}

--- a/src/EventSubscriber/IndexableDataFilter/EnabledFilter.php
+++ b/src/EventSubscriber/IndexableDataFilter/EnabledFilter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\EventSubscriber\IndexableDataFilter;
+
+use Setono\SyliusMeilisearchPlugin\Event\QueryBuilderForDataProvisionCreated;
+use Sylius\Component\Resource\Model\ToggleableInterface;
+
+final class EnabledFilter extends AbstractFilter
+{
+    public function __construct(private readonly string $index)
+    {
+    }
+
+    public function filter(QueryBuilderForDataProvisionCreated $event): void
+    {
+        if ($event->index->name !== $this->index) {
+            return;
+        }
+
+        if (is_a($event->entity, ToggleableInterface::class, true)) {
+            $event->qb->andWhere(sprintf('%s.enabled = true', self::getRootAlias($event->qb)));
+        }
+    }
+}

--- a/src/EventSubscriber/IndexableDataFilter/StockAvailableFilter.php
+++ b/src/EventSubscriber/IndexableDataFilter/StockAvailableFilter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\EventSubscriber\IndexableDataFilter;
+
+use Setono\SyliusMeilisearchPlugin\Event\QueryBuilderForDataProvisionCreated;
+use Sylius\Component\Core\Model\ProductInterface;
+
+final class StockAvailableFilter extends AbstractFilter
+{
+    public function __construct(private readonly string $index)
+    {
+    }
+
+    public function filter(QueryBuilderForDataProvisionCreated $event): void
+    {
+        if ($event->index->name !== $this->index) {
+            return;
+        }
+
+        if (!is_a($event->entity, ProductInterface::class, true)) {
+            return;
+        }
+
+        $event->qb->join(sprintf('%s.variants', self::getRootAlias($event->qb)), 'variant')
+            ->andWhere('variant.tracked = false OR ((variant.onHand - variant.onHold) > 0)')
+        ;
+    }
+}

--- a/src/Filter/Entity/ChannelsAwareEntityFilter.php
+++ b/src/Filter/Entity/ChannelsAwareEntityFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Filter\Entity;
+
+use Setono\SyliusMeilisearchPlugin\Document\Document;
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Sylius\Component\Channel\Model\ChannelsAwareInterface;
+
+final class ChannelsAwareEntityFilter implements EntityFilterInterface
+{
+    public function __construct(private readonly string $index)
+    {
+    }
+
+    public function filter(IndexableInterface $entity, Document $document, IndexScope $indexScope): bool
+    {
+        if ($indexScope->index->name !== $this->index) {
+            return true;
+        }
+
+        if (null === $indexScope->channelCode) {
+            return true;
+        }
+
+        if (!$entity instanceof ChannelsAwareInterface) {
+            return true;
+        }
+
+        foreach ($entity->getChannels() as $channel) {
+            if ($indexScope->channelCode === $channel->getCode()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Application/config/packages/setono_sylius_meilisearch.yaml
+++ b/tests/Application/config/packages/setono_sylius_meilisearch.yaml
@@ -3,6 +3,8 @@ setono_sylius_meilisearch:
         products:
             document: 'Setono\SyliusMeilisearchPlugin\Tests\Application\Document\Product'
             entities: [ 'Setono\SyliusMeilisearchPlugin\Tests\Application\Entity\Product' ]
+            default_filters:
+                stock_available: true
         taxons:
             document: 'Setono\SyliusMeilisearchPlugin\Document\Taxon'
             entities: [ 'Setono\SyliusMeilisearchPlugin\Tests\Application\Entity\Taxon' ]


### PR DESCRIPTION
This PR will add some default filters to data retrieval when applicable. An example could be the `ProductInterface` that extends the `ToggleableInterface`. When that's the case we will add an 'enabled' filter automatically to the data retrieval of that entity class.

Right now there are three types:
- 'enabled'
- 'channels_aware'
- 'stock_available'