### PR TITLE
Display proper number of results on pagination

### DIFF
--- a/src/Controller/Action/SearchAction.php
+++ b/src/Controller/Action/SearchAction.php
@@ -8,6 +8,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Setono\Doctrine\ORMTrait;
 use Setono\SyliusMeilisearchPlugin\Engine\SearchEngineInterface;
 use Setono\SyliusMeilisearchPlugin\Form\Builder\SearchFormBuilderInterface;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Provider\SearchResultDataProvider;
 use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -54,6 +55,8 @@ final class SearchAction
 
         return new Response($this->twig->render('@SetonoSyliusMeilisearchPlugin/search/index.html.twig', [
             'searchResult' => $searchResult,
+            'pageStartHit' => SearchResultDataProvider::getPageStartHit($searchResult),
+            'pageEndHit' => SearchResultDataProvider::getPageEndHit($searchResult),
             'searchForm' => $searchForm->createView(),
             'items' => $items,
         ]));

--- a/src/Meilisearch/Provider/SearchResultDataProvider.php
+++ b/src/Meilisearch/Provider/SearchResultDataProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Meilisearch\Provider;
+
+use Meilisearch\Search\SearchResult;
+
+final class SearchResultDataProvider
+{
+    public static function getPageStartHit(SearchResult $searchResult): int
+    {
+        return (int) $searchResult->getPage() * (int) $searchResult->getHitsPerPage() - (int) $searchResult->getHitsPerPage();
+    }
+
+    public static function getPageEndHit(SearchResult $searchResult): int
+    {
+        $totalHits = (int) $searchResult->getTotalHits();
+        $page = (int) $searchResult->getPage();
+        $hitsPerPage = (int) $searchResult->getHitsPerPage();
+
+        return ($totalHits < $page * $hitsPerPage) ? $totalHits : $page * $hitsPerPage;
+    }
+}

--- a/src/Resources/views/search/index.html.twig
+++ b/src/Resources/views/search/index.html.twig
@@ -16,7 +16,7 @@
                 <div class="twelve wide column">
                     <div class="ui grid">
                         <div class="eight wide column">
-                            Displaying {{ (searchResult.page * searchResult.hitsPerPage) - searchResult.hitsPerPage }} - {{ searchResult.page * searchResult.hitsPerPage }} of {{ searchResult.hitsCount }}
+                            Displaying {{ pageStartHit }} - {{ pageEndHit }} of {{ searchResult.hitsCount }}
                         </div>
                         <div class="eight wide right aligned column">
                             {{ form_widget(searchForm.sort) }}


### PR DESCRIPTION
I've changed the max results per page to 5 to show results better 🖖 Previously it was always displaying "0 - {maxHitsPerPage}"


https://github.com/user-attachments/assets/e08614d4-842f-47e7-bd1f-c075c2ae8501

