### PR TITLE
Fix static analysis

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -28,4 +28,12 @@
         <function name="var_dump"/>
         <function name="print_r"/>
     </forbiddenFunctions>
+    <issueHandlers>
+        <TooManyTemplateParams>
+            <errorLevel type="suppress">
+                <directory name="src/Factory"/>
+                <directory name="src/Repository"/>
+            </errorLevel>
+        </TooManyTemplateParams>
+    </issueHandlers>
 </psalm>

--- a/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
+++ b/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
@@ -43,7 +43,7 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
          * @var array{
          *      indexes: array<string, array{document: class-string<Document>, entities: list<class-string>, data_provider: class-string, indexer: class-string|null, prefix: string|null, default_filters: array<string, bool>}>,
          *      server: array{ host: string, master_key: string },
-         *      search: array{ enabled: bool, path: string, index: string, hits_per_page: integer },
+         *      search: array{ enabled: bool, path: string, index: string, hits_per_page: int },
          *      resources: array,
          * } $config
          */
@@ -285,7 +285,7 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
     /**
      * todo the search controller should only be available when search is enabled
      *
-     * @param array{ enabled: bool, path: string, index: string, hits_per_page: integer } $config the search configuration
+     * @param array{ enabled: bool, path: string, index: string, hits_per_page: int } $config the search configuration
      * @param list<string> $indexes a list of index names
      */
     private static function registerSearchConfiguration(array $config, array $indexes, ContainerBuilder $container, LoaderInterface $loader): void


### PR DESCRIPTION
~`@extends FactoryInterface<SynonymInterface>` and `@extends RepositoryInterface<SynonymInterface>` unfortunately work only (or at least - do not bother Psalm) with SyliusResourceBundle 1.11 and newer versions of those interfaces. Which, unfortunately, we cannot assume, as the plugin depends on version `^1.6`.~ You can see the current error e.g. [here](https://github.com/Setono/sylius-meilisearch-plugin/actions/runs/10639312018/job/29497043457).

~Alternatively, I can suppress those errors in the psalm configuration, the decision is up to you @loevgaard 🖖 ~

EDIT: I think we just need to skip it, because in other way in some situations we get `MissingTemplateParam` error :dancer: