### PR TITLE
Add simple popularity metric to be able to rank results based on popularity

### DIFF
--- a/src/DataMapper/Product/PopularityDataMapper.php
+++ b/src/DataMapper/Product/PopularityDataMapper.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\DataMapper\Product;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Setono\Doctrine\ORMTrait;
+use Setono\SyliusMeilisearchPlugin\DataMapper\DataMapperInterface;
+use Setono\SyliusMeilisearchPlugin\Document\Document;
+use Setono\SyliusMeilisearchPlugin\Document\Product;
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Product\Model\ProductVariantInterface;
+use Webmozart\Assert\Assert;
+
+final class PopularityDataMapper implements DataMapperInterface
+{
+    use ORMTrait;
+
+    public function __construct(
+        ManagerRegistry $managerRegistry,
+        /** @var class-string $orderClass */
+        private readonly string $orderClass,
+        /** @var class-string $orderItemClass */
+        private readonly string $orderItemClass,
+        private readonly string $popularityLookBackPeriod = '3 months',
+    ) {
+        $this->managerRegistry = $managerRegistry;
+    }
+
+    /**
+     * @param Product|Document $target
+     * @param array<string, mixed> $context
+     */
+    public function map(IndexableInterface $source, Document $target, IndexScope $indexScope, array $context = []): void
+    {
+        Assert::true(
+            $this->supports($source, $target, $indexScope, $context),
+            'The given $source and $target is not supported',
+        );
+
+        $variants = $source->getEnabledVariants()->map(static fn (ProductVariantInterface $variant): int => (int) $variant->getId())->toArray();
+        if ([] === $variants) {
+            return;
+        }
+
+        $orderIdLowerBound = $this->getOrderIdLowerBound();
+
+        // todo do we need some filters on the order? E.g. state...
+
+        $qb = $this->getManager($this->orderItemClass)
+            ->createQueryBuilder()
+            ->select('SUM(o.quantity)')
+            ->from($this->orderItemClass, 'o')
+            ->andWhere('IDENTITY(o.order) >= :orderIdLowerBound')
+            ->andWhere('o.variant IN (:variants)')
+            ->setParameter('orderIdLowerBound', $orderIdLowerBound)
+            ->setParameter('variants', $variants)
+        ;
+
+        // todo in the future this value should be normalized so that it will be easier for plugin users to add to the popularity score
+        $target->popularity = (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @psalm-assert-if-true ProductInterface $source
+     * @psalm-assert-if-true Product $target
+     */
+    public function supports(
+        IndexableInterface $source,
+        Document $target,
+        IndexScope $indexScope,
+        array $context = [],
+    ): bool {
+        return $source instanceof ProductInterface && $target instanceof Product;
+    }
+
+    private function getOrderIdLowerBound(): int
+    {
+        return (int) $this->getManager($this->orderClass)
+            ->createQueryBuilder()
+            ->select('o.id')
+            ->from($this->orderClass, 'o')
+            ->andwhere('o.createdAt >= :date')
+            ->setMaxResults(1)
+            ->addOrderBy('o.id', 'ASC')
+            ->setParameter('date', new \DateTimeImmutable('-' . $this->popularityLookBackPeriod))
+            ->getQuery()
+            ->enableResultCache(3600) // todo should this be cached and should it be configurable?
+            ->getSingleScalarResult()
+        ;
+    }
+}

--- a/src/Document/Product.php
+++ b/src/Document/Product.php
@@ -37,6 +37,8 @@ class Product extends Document implements UrlAwareInterface, ImageAwareInterface
 
     public ?float $originalPrice = null;
 
+    public float $popularity = 0.0;
+
     /**
      * This attribute will allow you to create a filter like 'Only show products on sale'
      */

--- a/src/Provider/Settings/CompositeSettingsProvider.php
+++ b/src/Provider/Settings/CompositeSettingsProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Provider\Settings;
+
+use Setono\CompositeCompilerPass\CompositeService;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Setono\SyliusMeilisearchPlugin\Settings\Settings;
+
+/**
+ * @extends CompositeService<SettingsProviderInterface>
+ */
+final class CompositeSettingsProvider extends CompositeService implements SettingsProviderInterface
+{
+    public function getSettings(IndexScope $indexScope): Settings
+    {
+        foreach ($this->services as $service) {
+            if ($service->supports($indexScope)) {
+                return $service->getSettings($indexScope);
+            }
+        }
+
+        throw new \RuntimeException('No settings provider supports the given index scope');
+    }
+
+    public function supports(IndexScope $indexScope): bool
+    {
+        foreach ($this->services as $service) {
+            if ($service->supports($indexScope)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Provider/Settings/DefaultSettingsProvider.php
+++ b/src/Provider/Settings/DefaultSettingsProvider.php
@@ -9,7 +9,7 @@ use Setono\SyliusMeilisearchPlugin\Meilisearch\SynonymResolverInterface;
 use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
 use Setono\SyliusMeilisearchPlugin\Settings\Settings;
 
-final class SettingsProvider implements SettingsProviderInterface
+final class DefaultSettingsProvider implements SettingsProviderInterface
 {
     public function __construct(
         private readonly SynonymResolverInterface $synonymResolver,
@@ -30,5 +30,10 @@ final class SettingsProvider implements SettingsProviderInterface
         $settings->synonyms = $this->synonymResolver->resolve($indexScope);
 
         return $settings;
+    }
+
+    public function supports(IndexScope $indexScope): bool
+    {
+        return true;
     }
 }

--- a/src/Provider/Settings/ProductSettingsProvider.php
+++ b/src/Provider/Settings/ProductSettingsProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Provider\Settings;
+
+use Setono\SyliusMeilisearchPlugin\Document\Product;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Setono\SyliusMeilisearchPlugin\Settings\Settings;
+
+final class ProductSettingsProvider implements SettingsProviderInterface
+{
+    public function __construct(private readonly SettingsProviderInterface $defaultSettingsProvider)
+    {
+    }
+
+    public function getSettings(IndexScope $indexScope): Settings
+    {
+        $settings = $this->defaultSettingsProvider->getSettings($indexScope);
+
+        $settings->rankingRules->add('popularity:desc');
+
+        return $settings;
+    }
+
+    public function supports(IndexScope $indexScope): bool
+    {
+        return is_a($indexScope->index->document, Product::class, true);
+    }
+}

--- a/src/Provider/Settings/SettingsProviderInterface.php
+++ b/src/Provider/Settings/SettingsProviderInterface.php
@@ -10,4 +10,6 @@ use Setono\SyliusMeilisearchPlugin\Settings\Settings;
 interface SettingsProviderInterface
 {
     public function getSettings(IndexScope $indexScope): Settings;
+
+    public function supports(IndexScope $indexScope): bool;
 }

--- a/src/Resources/config/services/data_mapper.xml
+++ b/src/Resources/config/services/data_mapper.xml
@@ -58,6 +58,14 @@
             <tag name="setono_sylius_meilisearch.data_mapper" priority="160"/>
         </service>
 
+        <service id="Setono\SyliusMeilisearchPlugin\DataMapper\Product\PopularityDataMapper">
+            <argument type="service" id="doctrine"/>
+            <argument>%sylius.model.order.class%</argument>
+            <argument>%sylius.model.order_item.class%</argument>
+
+            <tag name="setono_sylius_meilisearch.data_mapper" priority="160"/>
+        </service>
+
         <!-- Taxon data mappers -->
         <service id="Setono\SyliusMeilisearchPlugin\DataMapper\Taxon\TaxonDataMapper">
             <tag name="setono_sylius_meilisearch.data_mapper" priority="100"/>

--- a/src/Resources/config/services/provider.xml
+++ b/src/Resources/config/services/provider.xml
@@ -27,11 +27,21 @@
 
         <!-- Settings providers -->
         <service id="Setono\SyliusMeilisearchPlugin\Provider\Settings\SettingsProviderInterface"
-                 alias="Setono\SyliusMeilisearchPlugin\Provider\Settings\SettingsProvider"/>
+                 alias="Setono\SyliusMeilisearchPlugin\Provider\Settings\CompositeSettingsProvider"/>
 
-        <service id="Setono\SyliusMeilisearchPlugin\Provider\Settings\SettingsProvider">
+        <service id="Setono\SyliusMeilisearchPlugin\Provider\Settings\CompositeSettingsProvider"/>
+
+        <service id="Setono\SyliusMeilisearchPlugin\Provider\Settings\ProductSettingsProvider">
+            <argument type="service" id="Setono\SyliusMeilisearchPlugin\Provider\Settings\DefaultSettingsProvider"/>
+
+            <tag name="setono_sylius_meilisearch.settings_provider" priority="-40"/>
+        </service>
+
+        <service id="Setono\SyliusMeilisearchPlugin\Provider\Settings\DefaultSettingsProvider">
             <argument type="service" id="Setono\SyliusMeilisearchPlugin\Meilisearch\SynonymResolverInterface"/>
             <argument type="service" id="Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactoryInterface"/>
+
+            <tag name="setono_sylius_meilisearch.settings_provider" priority="-50"/>
         </service>
     </services>
 </container>

--- a/src/SetonoSyliusMeilisearchPlugin.php
+++ b/src/SetonoSyliusMeilisearchPlugin.php
@@ -10,6 +10,7 @@ use Setono\SyliusMeilisearchPlugin\Filter\Entity\CompositeEntityFilter;
 use Setono\SyliusMeilisearchPlugin\Form\Builder\CompositeFacetFormBuilder;
 use Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\CompositeFilterBuilder;
 use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\CompositeIndexScopeProvider;
+use Setono\SyliusMeilisearchPlugin\Provider\Settings\CompositeSettingsProvider;
 use Sylius\Bundle\CoreBundle\Application\SyliusPluginTrait;
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
@@ -49,6 +50,11 @@ final class SetonoSyliusMeilisearchPlugin extends AbstractResourceBundle
         $container->addCompilerPass(new CompositeCompilerPass(
             CompositeIndexScopeProvider::class,
             'setono_sylius_meilisearch.index_scope_provider',
+        ));
+
+        $container->addCompilerPass(new CompositeCompilerPass(
+            CompositeSettingsProvider::class,
+            'setono_sylius_meilisearch.settings_provider',
         ));
 
         $container->addCompilerPass(new CompositeCompilerPass(


### PR DESCRIPTION
This PR adds a `$popularity` float to the `Product` document. This in turn is used to rank results based on this property.