### PR TITLE
Rename 'sort' query parameter to 's'

### DIFF
--- a/src/Engine/SearchRequest.php
+++ b/src/Engine/SearchRequest.php
@@ -8,6 +8,14 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class SearchRequest
 {
+    public const QUERY_PARAMETER_SEARCH = 'q';
+
+    public const QUERY_PARAMETER_PAGE = 'p';
+
+    public const QUERY_PARAMETER_SORT = 's';
+
+    public const QUERY_PARAMETER_FILTER = 'facets';
+
     // todo we need the hits per page here
     public function __construct(
         public readonly ?string $query,
@@ -20,15 +28,14 @@ final class SearchRequest
 
     public static function fromRequest(Request $request): self
     {
-        $q = $request->query->get('q');
+        $q = $request->query->get(self::QUERY_PARAMETER_SEARCH);
         if (!is_string($q)) {
             $q = null;
         }
 
-        $page = max(1, (int) $request->query->get('p', 1));
+        $page = max(1, (int) $request->query->get(self::QUERY_PARAMETER_PAGE, 1));
 
-        // todo rename sort to s?
-        $sort = $request->query->get('sort');
+        $sort = $request->query->get(self::QUERY_PARAMETER_SORT);
         if (!is_string($sort)) {
             $sort = null;
         }

--- a/src/Form/Builder/SearchFormBuilder.php
+++ b/src/Form/Builder/SearchFormBuilder.php
@@ -7,6 +7,7 @@ namespace Setono\SyliusMeilisearchPlugin\Form\Builder;
 use Meilisearch\Search\SearchResult;
 use Setono\SyliusMeilisearchPlugin\Config\Index;
 use Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactoryInterface;
+use Setono\SyliusMeilisearchPlugin\Engine\SearchRequest;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -118,7 +119,7 @@ final class SearchFormBuilder implements SearchFormBuilderInterface
 
         $searchFormBuilder->add($facetsFormBuilder);
 
-        $searchFormBuilder->add('sort', ChoiceType::class, [
+        $searchFormBuilder->add(SearchRequest::QUERY_PARAMETER_SORT, ChoiceType::class, [
             'choices' => [
                 'Cheapest first' => 'price:asc',
                 'Biggest discount' => 'discount:desc',

--- a/src/Resources/public/js/search.js
+++ b/src/Resources/public/js/search.js
@@ -70,7 +70,7 @@ class SearchManager {
                 field.dispatchEvent(new CustomEvent('search:facet-changed', { bubbles: true }));
             } else if(field.name === 'p') {
                 field.dispatchEvent(new CustomEvent('search:page-changed', { bubbles: true }));
-            } else if(field.name.startsWith('sort')) {
+            } else if(field.classList.contains('sort')) {
                 field.dispatchEvent(new CustomEvent('search:sort-changed', { bubbles: true }));
             }
         });

--- a/src/Resources/views/search/_sorting.html.twig
+++ b/src/Resources/views/search/_sorting.html.twig
@@ -1,1 +1,1 @@
-{{ form_widget(searchForm.sort) }}
+{{ form_widget(searchForm.s, { 'attr': { 'class': 'sort' } }) }}

--- a/tests/Application/templates/bundles/SetonoSyliusMeilisearchPlugin/search/index.html.twig
+++ b/tests/Application/templates/bundles/SetonoSyliusMeilisearchPlugin/search/index.html.twig
@@ -84,13 +84,13 @@
         /**
          * Sort
          */
-        #sort {
+        .sort {
             padding: 0 !important;
             margin: 0 !important;
             text-align-last: right;
         }
 
-        #sort option {
+        .sort option {
             direction: rtl;
         }
     </style>

--- a/tests/Unit/Engine/SearchRequestTest.php
+++ b/tests/Unit/Engine/SearchRequestTest.php
@@ -33,7 +33,7 @@ final class SearchRequestTest extends TestCase
      */
     public function it_creates_from_request(): void
     {
-        $request = Request::create('/search', 'GET', ['q' => 'jeans', 'facets' => ['brand' => ['Celsius small', 'You are breathtaking'], 'price' => ['min' => '30', 'max' => '45']], 'p' => 2, 'sort' => 'price:asc']);
+        $request = Request::create('/search', 'GET', ['q' => 'jeans', 'facets' => ['brand' => ['Celsius small', 'You are breathtaking'], 'price' => ['min' => '30', 'max' => '45']], 'p' => 2, 's' => 'price:asc']);
         $searchRequest = SearchRequest::fromRequest($request);
 
         self::assertSame('jeans', $searchRequest->query);


### PR DESCRIPTION
This is only done to make the query string shorter. There will be another PR doing the same for facets/filters, so we end up having `p`, `s`, `f`, and `q` as root level query parameters for the search