### PR TITLE
Add Playwright e2e tests for search and autocomplete

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -218,7 +218,7 @@ jobs:
 
         services:
             meilisearch:
-                image: "getmeili/meilisearch:v1.10"
+                image: "getmeili/meilisearch:v1.49"
                 env:
                     MEILI_MASTER_KEY: aSampleMasterKey
                 ports:
@@ -266,6 +266,96 @@ jobs:
 
             -   name: "Run phpunit"
                 run: "vendor/bin/phpunit --testsuite Functional"
+
+    e2e-tests:
+        name: "End-to-end tests (PHP${{ matrix.php-version }} | Deps: ${{ matrix.dependencies }} | SF${{ matrix.symfony }})"
+
+        runs-on: "ubuntu-latest"
+
+        strategy:
+            matrix:
+                php-version:
+                    - "8.3"
+
+                dependencies:
+                    - "highest"
+
+                symfony:
+                    - "~6.4.0"
+
+        services:
+            meilisearch:
+                image: "getmeili/meilisearch:v1.49"
+                env:
+                    MEILI_MASTER_KEY: aSampleMasterKey
+                ports:
+                    - "7700:7700"
+
+        steps:
+            -   name: "Start MySQL"
+                run: "sudo /etc/init.d/mysql start"
+
+            -   name: "Checkout"
+                uses: "actions/checkout@v6"
+
+            -   name: "Setup PHP, with composer and extensions"
+                uses: "shivammathur/setup-php@v2"
+                with:
+                    coverage: "none"
+                    extensions: "${{ env.PHP_EXTENSIONS }}"
+                    php-version: "${{ matrix.php-version }}"
+                    tools: "flex, symfony"
+
+            -   name: "Install composer dependencies"
+                uses: "ramsey/composer-install@v3"
+                env:
+                    SYMFONY_REQUIRE: "${{ matrix.symfony }}"
+                with:
+                    dependency-versions: "${{ matrix.dependencies }}"
+
+            -   name: "Setup Node"
+                uses: "actions/setup-node@v4"
+                with:
+                    node-version-file: "tests/Application/.nvmrc"
+                    cache: "yarn"
+                    cache-dependency-path: "tests/Application/package.json" # yarn.lock is not committed
+
+            -   name: "Install node dependencies"
+                run: "(cd tests/Application && yarn install)"
+
+            -   name: "Build frontend assets"
+                run: "(cd tests/Application && yarn build)"
+
+            -   name: "Install bundle assets"
+                run: "(cd tests/Application && bin/console assets:install public)"
+
+            -   name: "Create database"
+                run: "(cd tests/Application && bin/console doctrine:database:create)"
+
+            -   name: "Create database schema"
+                run: "(cd tests/Application && bin/console doctrine:schema:create)"
+
+            -   name: "Load fixtures"
+                run: "(cd tests/Application && bin/console sylius:fixtures:load -n -vvv)"
+
+            -   name: "Populate indexes"
+                run: "(cd tests/Application && bin/console setono:sylius-meilisearch:index --wait)"
+
+            -   name: "Install Playwright browser"
+                run: "(cd tests/Application && npx playwright install --with-deps chromium)"
+
+            -   name: "Run Playwright tests"
+                run: "(cd tests/Application && yarn e2e)"
+
+            -   name: "Upload Playwright report"
+                uses: "actions/upload-artifact@v4"
+                if: "failure()"
+                with:
+                    name: "playwright-report"
+                    path: |
+                        tests/Application/playwright-report/
+                        tests/Application/test-results/
+                    retention-days: 7
 
     mutation-tests:
         name: "Mutation tests"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ After changing code, run `composer fix-style`, `composer analyse`, and `(cd test
 
 ### Functional tests
 
-The Functional suite needs MariaDB/MySQL and Meilisearch on `:7700` with master key `aSampleMasterKey` (start one with `tests/Application/meilisearch.sh`, or see the service container in `.github/workflows/build.yaml`). Setup chain (all from `tests/Application`, with `APP_ENV=test` — the test env ignores `.env.local`, which may hold real cloud credentials):
+The Functional suite needs MariaDB/MySQL and Meilisearch on `:7700` with master key `aSampleMasterKey`. Start Meilisearch with `cd tests/Application && docker compose up -d --wait` (or `tests/Application/meilisearch.sh` without Docker; the CI service container is in `.github/workflows/build.yaml`). Keep the compose image version in sync with the CI service containers. Setup chain (all from `tests/Application`, with `APP_ENV=test` — the test env ignores `.env.local`, which may hold real cloud credentials):
 
 ```shell
 bin/console doctrine:database:create
@@ -32,7 +32,11 @@ bin/console setono:sylius-meilisearch:index --wait
 cd ../.. && vendor/bin/phpunit --testsuite Functional
 ```
 
-Note: repeated fixture loads accumulate stale documents in a long-lived local Meilisearch (indexes are only added to, never purged), which can make index-vs-database comparisons drift. CI uses a fresh container per run.
+Note: repeated fixture loads accumulate stale documents in a long-lived local Meilisearch (indexes are only added to, never purged), which can make index-vs-database comparisons drift. `docker compose down && docker compose up -d` resets the instance (the compose service has no volume); CI uses a fresh container per run.
+
+### E2E tests (Playwright)
+
+Browser tests for the shop search page and autocomplete widget live in `tests/Application/e2e/*.spec.ts` and run with `(cd tests/Application && yarn e2e)` (single-cell `e2e-tests` job in `build.yaml`). Prerequisites are the same DB/fixtures/index chain as Functional, plus `yarn install && yarn build && bin/console assets:install` and the Symfony CLI. `yarn e2e` auto-starts the app via `e2e/serve.sh`, which resolves `MEILISEARCH_SEARCH_KEY` from the running Meilisearch (the browser queries Meilisearch directly for autocomplete) and runs `symfony serve` in `APP_ENV=test`. The search form is AJAX-driven (`src/Resources/public/js/search.js` swaps the `#search-form` node + `history.pushState`), so specs wait on `toHaveURL(...)` after each interaction. Note: the untracked `.mcp.json` configures the Playwright MCP server for agent-driven browsing — unrelated to this suite.
 
 ### Dependency extremes
 

--- a/README.md
+++ b/README.md
@@ -279,11 +279,13 @@ vendor/bin/rector process --dry-run
 
 ### Running the functional tests
 
-The Functional suite needs MySQL/MariaDB and a Meilisearch instance on `localhost:7700`. You can start Meilisearch with the bundled helper (uses master key `aSampleMasterKey`, matching the defaults in `tests/Application/.env`):
+The Functional suite needs MySQL/MariaDB and a Meilisearch instance on `localhost:7700` (master key `aSampleMasterKey`, matching the defaults in `tests/Application/.env`). Start Meilisearch with the bundled compose file:
 
 ```shell
-tests/Application/meilisearch.sh
+cd tests/Application && docker compose up -d --wait   # `docker compose down` resets it to a clean state
 ```
+
+Without Docker, `tests/Application/meilisearch.sh` downloads and runs the Meilisearch binary instead.
 
 Then set up the test application and run the suite:
 
@@ -310,6 +312,24 @@ bin/console sylius:fixtures:load -n
 bin/console setono:sylius-meilisearch:index --wait
 symfony serve
 ```
+
+### Running the end-to-end tests
+
+The Playwright suite drives the shop search page and the autocomplete widget in a real browser. It needs the same MySQL/MariaDB + Meilisearch + fixtures + index setup as the Functional suite, plus built assets and the [Symfony CLI](https://symfony.com/download):
+
+```shell
+cd tests/Application
+docker compose up -d --wait
+yarn install && yarn build
+bin/console assets:install                       # APP_ENV=test for all console commands
+bin/console doctrine:database:create && bin/console doctrine:schema:create
+bin/console sylius:fixtures:load -n
+bin/console setono:sylius-meilisearch:index --wait
+npx playwright install chromium                  # first time only
+yarn e2e                                          # or: yarn e2e:ui
+```
+
+`yarn e2e` starts the app itself via `e2e/serve.sh` (which runs `symfony serve` on `127.0.0.1:8080` with `APP_ENV=test` and resolves the Meilisearch search key the autocomplete widget needs), so you don't start a server yourself.
 
 See [CLAUDE.md](CLAUDE.md) for a deeper tour of the architecture and conventions.
 

--- a/tests/Application/.gitignore
+++ b/tests/Application/.gitignore
@@ -16,6 +16,12 @@
 /meilisearch
 ###< meilisearch ###
 
+###> playwright ###
+/test-results/
+/playwright-report/
+/playwright/.cache/
+###< playwright ###
+
 ###> symfony/framework-bundle ###
 /.env.*.local
 /.env.local

--- a/tests/Application/compose.yaml
+++ b/tests/Application/compose.yaml
@@ -1,0 +1,21 @@
+# Meilisearch for the functional and end-to-end tests.
+# The database is not containerized (use your local MySQL/MariaDB, or the MySQL service in CI).
+# Keep the image version in sync with the service containers in .github/workflows/build.yaml.
+name: "setono-sylius-meilisearch-plugin"
+
+services:
+    meilisearch:
+        image: "getmeili/meilisearch:v1.49"
+        environment:
+            MEILI_MASTER_KEY: "aSampleMasterKey" # matches MEILISEARCH_MASTER_KEY in .env
+            MEILI_NO_ANALYTICS: "true"
+        ports:
+            - "7700:7700"
+        # No volume on purpose: `docker compose down && docker compose up -d` gives a fresh
+        # instance, which avoids the stale-document drift you get from a long-lived index.
+        # localhost resolves to IPv6 inside the container, but Meilisearch binds IPv4 only, so use 127.0.0.1
+        healthcheck:
+            test: ["CMD", "wget", "--quiet", "--spider", "http://127.0.0.1:7700/health"]
+            interval: "2s"
+            timeout: "3s"
+            retries: 30

--- a/tests/Application/e2e/autocomplete.spec.ts
+++ b/tests/Application/e2e/autocomplete.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+// The autocomplete widget (#autocomplete) is rendered in the shop header on every page and
+// queries Meilisearch DIRECTLY from the browser using the searchKey embedded in the page.
+
+test.describe('autocomplete widget', () => {
+    test('embeds a usable configuration', async ({ page }) => {
+        await page.goto('/en_US/');
+
+        const raw = await page.locator('#ssm-autocomplete-configuration').textContent();
+        const config = JSON.parse(raw ?? '{}');
+
+        // Fails fast (instead of the suggestions silently never loading) when the server was
+        // started without a resolved MEILISEARCH_SEARCH_KEY, i.e. not through e2e/serve.sh
+        expect(config.searchKey, 'MEILISEARCH_SEARCH_KEY is empty — start the server via e2e/serve.sh').not.toBe('');
+        expect(config.host).toMatch(/^https?:\/\//);
+        await expect(page.locator('#autocomplete .aa-Input')).toBeVisible();
+    });
+
+    test('suggests products while typing', async ({ page }) => {
+        await page.goto('/en_US/');
+
+        const input = page.locator('#autocomplete .aa-Input');
+        await input.click();
+        await input.pressSequentially('jeans', { delay: 50 });
+
+        // The panel is portalled onto the body, so it is not scoped to #autocomplete
+        await expect(page.locator('.aa-Panel')).toBeVisible();
+        await expect(page.locator('.aa-ItemContentTitle').filter({ hasText: /jeans/i }).first()).toBeVisible();
+    });
+
+    test('navigates to the product on selection', async ({ page }) => {
+        await page.goto('/en_US/');
+
+        const input = page.locator('#autocomplete .aa-Input');
+        await input.click();
+        await input.pressSequentially('jeans', { delay: 50 });
+        await expect(page.locator('.aa-ItemWrapper').first()).toBeVisible();
+
+        // onSelect sets location.href = item.url
+        await page.locator('.aa-ItemWrapper').first().click();
+        await expect(page).toHaveURL(/\/en_US\/products\//);
+        await expect(page.locator('h1')).toBeVisible();
+    });
+});

--- a/tests/Application/e2e/search.spec.ts
+++ b/tests/Application/e2e/search.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect, Page } from '@playwright/test';
+
+// The search form is AJAX-driven (src/Resources/public/js/search.js): interacting with a
+// filter/sort/page control submits via fetch, replaces the #search-form node, and pushes the
+// new URL with history.pushState. So we always wait on the URL as the completion signal before
+// re-reading the (replaced) DOM.
+
+const names = (page: Page) => page.locator('.sylius-product-name');
+
+async function prices(page: Page): Promise<number[]> {
+    const texts = await page.locator('.sylius-product-price').allTextContents();
+    return texts.map((t) => parseFloat(t.replace(/[^0-9.]/g, '')));
+}
+
+test.describe('shop search page', () => {
+    test('shows results for a query', async ({ page }) => {
+        await page.goto('/en_US/search?q=jeans');
+
+        await expect(page.locator('h1')).toContainText('jeans');
+        await expect(page.getByText('8 results')).toBeVisible();
+        await expect(names(page)).toHaveCount(3); // hits_per_page: 3
+    });
+
+    test('shows a message when there are no results', async ({ page }) => {
+        await page.goto('/en_US/search?q=thisdoesnotexistxyz');
+
+        await expect(page.locator('.ui.message .header')).toHaveText('No results found');
+        await expect(names(page)).toHaveCount(0);
+    });
+
+    test('paginates through the result set', async ({ page }) => {
+        await page.goto('/en_US/search?q=jeans');
+        const firstOnPage1 = await names(page).first().textContent();
+
+        // Pagination is Previous/Next; clicking "Next" fires an AJAX submit + pushState
+        await page.locator('nav.ssm-pagination label', { hasText: 'Next' }).click();
+        await expect(page).toHaveURL(/[?&]p=2(&|$)/);
+        await expect(names(page).first()).not.toHaveText(firstOnPage1 ?? '');
+
+        // Last page holds the remaining 2 of 8 hits and has no "Next" control
+        await page.goto('/en_US/search?q=jeans&p=3');
+        await expect(names(page)).toHaveCount(2);
+        await expect(page.locator('nav.ssm-pagination label', { hasText: 'Next' })).toHaveCount(0);
+    });
+
+    test('filters by a brand facet', async ({ page }) => {
+        await page.goto('/en_US/search?q=jeans');
+
+        // Checking the box auto-submits (there is no submit button in the form)
+        await page.locator('.ssm-filters input[name="f[brand][]"][value="Celsius Small"]').check();
+        await expect(page).toHaveURL(/f%5Bbrand%5D%5B%5D=Celsius/);
+        await expect(page.getByText('1 results')).toBeVisible();
+        await expect(names(page)).toHaveCount(1);
+    });
+
+    test('filters by a price range', async ({ page }) => {
+        await page.goto('/en_US/search?q=jeans');
+
+        // The min/max inputs are pre-filled with the current result set's bounds.
+        // Narrow to the upper half so at least one product still matches (prices are randomized).
+        const min = page.locator('#f_price_min');
+        const max = page.locator('#f_price_max');
+        const lo = parseFloat((await min.inputValue()) || '0');
+        const hi = parseFloat((await max.inputValue()) || '0');
+        const threshold = Math.ceil((lo + hi) / 2);
+
+        // Typeable inputs submit on blur; each submit replaces the form node, so serialize
+        await min.fill(String(threshold));
+        await min.blur();
+        await expect(page).toHaveURL(/f%5Bprice%5D%5Bmin%5D/);
+
+        await expect(names(page).first()).toBeVisible();
+        for (const price of await prices(page)) {
+            expect(price).toBeGreaterThanOrEqual(threshold);
+        }
+
+        // An impossible window renders the no-results block in place (it reuses #search-form)
+        await page.goto('/en_US/search?q=jeans&f[price][min]=999999');
+        await expect(page.locator('.ui.message .header')).toHaveText('No results found');
+    });
+
+    test('sorts by price ascending', async ({ page }) => {
+        await page.goto('/en_US/search?q=jeans');
+
+        await page.locator('select.ssm-sort').selectOption('price:asc'); // label: "Price: low to high"
+        await expect(page).toHaveURL(/s=price%3Aasc/);
+
+        const shown = await prices(page);
+        expect(shown.length).toBeGreaterThan(0);
+        expect(shown).toEqual([...shown].sort((a, b) => a - b));
+    });
+});

--- a/tests/Application/e2e/serve.sh
+++ b/tests/Application/e2e/serve.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -eu
+
+# Starts the test application for the Playwright end-to-end suite.
+#
+# The autocomplete widget queries Meilisearch directly from the browser using
+# MEILISEARCH_SEARCH_KEY, which is not set in .env. We resolve the instance's
+# auto-generated search-only key here and export it before starting the server.
+
+# Always run from tests/Application, regardless of the caller's working directory
+cd "$(dirname "$0")/.."
+
+MEILISEARCH_URL="${MEILISEARCH_URL:-http://localhost:7700}"
+MEILISEARCH_MASTER_KEY="${MEILISEARCH_MASTER_KEY:-aSampleMasterKey}"
+PORT="${E2E_PORT:-8080}"
+
+# Wait for Meilisearch to be reachable (max ~30s)
+tries=0
+until curl -fsS "$MEILISEARCH_URL/health" >/dev/null 2>&1; do
+    tries=$((tries + 1))
+    if [ "$tries" -gt 30 ]; then
+        echo "Meilisearch is not reachable at $MEILISEARCH_URL." >&2
+        echo "Start it with: docker compose up -d --wait   (from tests/Application)" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+# Resolve the "Default Search API Key" (the key whose actions are exactly ["search"]).
+# Uses PHP rather than jq so we don't add a tooling dependency.
+MEILISEARCH_SEARCH_KEY="$(MEILISEARCH_URL="$MEILISEARCH_URL" MEILISEARCH_MASTER_KEY="$MEILISEARCH_MASTER_KEY" php -r '
+    $response = file_get_contents(getenv("MEILISEARCH_URL") . "/keys", false, stream_context_create([
+        "http" => ["header" => "Authorization: Bearer " . getenv("MEILISEARCH_MASTER_KEY")],
+    ]));
+    if (false === $response) {
+        fwrite(STDERR, "Could not read the API keys from Meilisearch" . PHP_EOL);
+        exit(1);
+    }
+    foreach (json_decode($response, true)["results"] as $key) {
+        if (["search"] === $key["actions"]) {
+            echo $key["key"];
+            exit(0);
+        }
+    }
+    fwrite(STDERR, "No search-only API key found on the Meilisearch instance" . PHP_EOL);
+    exit(1);
+')"
+
+export MEILISEARCH_SEARCH_KEY
+export APP_ENV="${APP_ENV:-test}"
+
+echo "Serving tests/Application at http://127.0.0.1:$PORT (APP_ENV=$APP_ENV)"
+exec symfony serve --no-tls --port="$PORT"

--- a/tests/Application/package.json
+++ b/tests/Application/package.json
@@ -3,10 +3,13 @@
   "scripts": {
     "build": "encore dev",
     "build:prod": "encore production",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
     "postinstall": "semantic-ui-css-patch",
     "watch": "encore dev --watch"
   },
   "devDependencies": {
+    "@playwright/test": "1.61.1",
     "@sylius-ui/frontend": "^1.0.3"
   },
   "resolutions": {

--- a/tests/Application/playwright.config.ts
+++ b/tests/Application/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const port = Number(process.env.E2E_PORT ?? 8080);
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+    testDir: './e2e',
+    outputDir: './test-results',
+    // A single shared app instance is served, so keep the tests serial
+    fullyParallel: false,
+    workers: 1,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    timeout: 60_000,
+    // AJAX search round-trips go through PHP and Meilisearch
+    expect: { timeout: 10_000 },
+    reporter: [['list'], ['html', { open: 'never' }]],
+    use: {
+        baseURL,
+        trace: 'on-first-retry',
+    },
+    projects: [
+        // A desktop viewport keeps the autocomplete widget out of its ≤680px "detached" mode
+        { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    ],
+    webServer: {
+        command: './e2e/serve.sh',
+        url: `${baseURL}/en_US/`,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+    },
+});


### PR DESCRIPTION
## Summary

Adds browser-level coverage for the two plugin UI features the Functional PHPUnit suite can't reach — the shop **search page** and the **autocomplete widget** — plus a `tests/Application/compose.yaml` so local testing is one `docker compose up` away.

## What's included

- **`tests/Application/compose.yaml`** — a single Meilisearch service (the DB stays local MySQL/MariaDB, or the MySQL service in CI). No volume, so `docker compose down && up -d` gives a clean instance (fixes the stale-document drift a long-lived index accumulates). Image bumped to **v1.49** and kept in sync with the CI service containers (the `integration-tests` service is bumped from v1.10 to match).
- **`tests/Application/e2e/serve.sh`** — resolves the Meilisearch search-only API key (the autocomplete widget queries Meilisearch **directly from the browser**, and `MEILISEARCH_SEARCH_KEY` is otherwise unset) and starts `symfony serve` in `APP_ENV=test`.
- **`playwright.config.ts` + `e2e/search.spec.ts` + `e2e/autocomplete.spec.ts`** — chromium, desktop viewport (keeps autocomplete out of its ≤680px detached mode). The search form is AJAX-driven (`search.js` swaps the `#search-form` node and `history.pushState`s the URL), so specs wait on `toHaveURL(...)` after each interaction and serialize the price-input blurs.
- **New `e2e-tests` CI job** (single cell: PHP 8.3 × highest × Symfony ~6.4.0) — reuses the integration-tests setup, installs the Symfony CLI via `setup-php` `tools`, builds assets, loads fixtures + indexes, runs Playwright, and uploads the HTML report artifact on failure.
- **Docs** — README and CLAUDE.md now use `docker compose up -d --wait` as the primary way to start Meilisearch (with `meilisearch.sh` as the Docker-free fallback) and document the e2e flow.

## Test scenarios

Search: results for `jeans` (8 hits, 3 per page), pagination (Previous/Next), brand facet (`Celsius Small` → 1 hit), price-range narrowing, price-ascending sort, and no-results. Autocomplete: config guard (fails loudly if the search key didn't resolve), suggestions while typing, and product navigation on select.

## Verification

Ran the full suite locally against a v1.49 Meilisearch (master key `aSampleMasterKey`, identical to the compose/CI service) — **9/9 passing across 4 consecutive runs, no flakes** (~11s each). The compose file's config validates and its container reaches `healthy` in ~2s. The `e2e-tests` CI job exercises the real 7700-default path on a fresh service container.

Note: the `.mcp.json` at the repo root (Playwright MCP server for agent-driven browsing) is intentionally left untracked — unrelated to this suite.