### PR TITLE
URL-encode the autocomplete query on submit

### DIFF
--- a/src/Resources/public/js/autocomplete.js
+++ b/src/Resources/public/js/autocomplete.js
@@ -80,7 +80,7 @@ if(configuration.searchParameter) {
 
     if (configuration.searchPath) {
         autocompleteConfig.onSubmit = ({event, state}) => {
-            location.href = `${configuration.searchPath}?${configuration.searchParameter}=${state.query}`;
+            location.href = `${configuration.searchPath}?${configuration.searchParameter}=${encodeURIComponent(state.query)}`;
         }
     }
 }


### PR DESCRIPTION
Fixes #90

## Problem

```js
location.href = `${configuration.searchPath}?${configuration.searchParameter}=${state.query}`;
```

Submitting a query containing `&`, `#`, `+` or `%` produced a wrong/truncated `q` parameter on the search page (e.g. `bolt & nut` arrived as `bolt `).

## Fix

```js
location.href = `${configuration.searchPath}?${configuration.searchParameter}=${encodeURIComponent(state.query)}`;
```

---

> [!NOTE]
> Part of the #88 → #97 stack. **Base: `issue-89-object-assign`** (#100).