### PR TITLE
Add configurable hit limit for autocomplete sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ setono_sylius_meilisearch:
         enabled: true
         indexes: [ products ]
         container: '#autocomplete'   # CSS selector for the element the widget mounts on
+        limit: 5                     # max suggestions to fetch per source
 ```
 
 The widget talks to Meilisearch directly from the browser using the (read-only) `MEILISEARCH_SEARCH_KEY`, so make sure that key is a search-only key.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -167,6 +167,11 @@ INFO, ToggleableInterface::class, EntityFilterInterface::class, QueryBuilderForD
                             ->defaultValue('setono_sylius_meilisearch.ui.search_placeholder')
                             ->info('This is the placeholder text that will be displayed in the input field')
                             ->cannotBeEmpty()
+                        ->end()
+                        ->integerNode('limit')
+                            ->defaultValue(5)
+                            ->info('The maximum number of suggestions to fetch per autocomplete source')
+                            ->min(1)
         ;
 
         return $treeBuilder;

--- a/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
+++ b/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
@@ -53,7 +53,7 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
          *      server: array{ url: string, public_url: string|null, master_key: string, search_key: string },
          *      metadata: array{ cache: bool },
          *      search: array{ enabled: bool, path: string, index: string, hits_per_page: int, taxon: array{ path: string } },
-         *      autocomplete: array{ enabled: bool, indexes: list<string>, container: string, placeholder: string },
+         *      autocomplete: array{ enabled: bool, indexes: list<string>, container: string, placeholder: string, limit: int },
          *      resources: array,
          * } $config
          */
@@ -423,7 +423,7 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
     }
 
     /**
-     * @param array{ enabled: bool, indexes: list<string>, container: string, placeholder: string } $config
+     * @param array{ enabled: bool, indexes: list<string>, container: string, placeholder: string, limit: int } $config
      * @param list<string> $indexes a list of configured index names
      */
     private static function registerAutocompleteConfiguration(array $config, array $indexes, ContainerBuilder $container, LoaderInterface $loader): void
@@ -446,6 +446,7 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
 
         $container->setParameter('setono_sylius_meilisearch.autocomplete.container', $config['container']);
         $container->setParameter('setono_sylius_meilisearch.autocomplete.placeholder', $config['placeholder']);
+        $container->setParameter('setono_sylius_meilisearch.autocomplete.limit', $config['limit']);
 
         $loader->load('services/conditional/autocomplete.xml');
 

--- a/src/Meilisearch/Autocomplete/Configuration/Source.php
+++ b/src/Meilisearch/Autocomplete/Configuration/Source.php
@@ -13,6 +13,8 @@ final class Source
         public readonly ?string $urlAttribute = null,
         /** @var array<string, string> $templates */
         public readonly array $templates = [],
+        /** The maximum number of suggestions to fetch for this source */
+        public readonly int $limit = 5,
     ) {
     }
 

--- a/src/Resources/config/services/conditional/autocomplete.xml
+++ b/src/Resources/config/services/conditional/autocomplete.xml
@@ -10,6 +10,7 @@
             <argument>%setono_sylius_meilisearch.server.search_key%</argument>
             <argument>%setono_sylius_meilisearch.autocomplete.container%</argument>
             <argument>%setono_sylius_meilisearch.autocomplete.placeholder%</argument>
+            <argument>%setono_sylius_meilisearch.autocomplete.limit%</argument>
             <argument type="collection"/> <!-- Gets set in the extension -->
             <argument>%kernel.debug%</argument>
 

--- a/src/Resources/public/js/autocomplete.js
+++ b/src/Resources/public/js/autocomplete.js
@@ -17,6 +17,7 @@
      * @property {string} index - Resolved Meilisearch index uid to query.
      * @property {?string} urlAttribute - Item attribute holding the URL to open when selected.
      * @property {Object.<string, string>} templates - Map of template name to an Algolia `html` template string.
+     * @property {number} limit - Maximum number of suggestions to fetch for this source.
      */
 
     /**
@@ -108,6 +109,7 @@
                             {
                                 indexName: source.index,
                                 query,
+                                params: { hitsPerPage: source.limit },
                             },
                         ],
                     });

--- a/src/Twig/AutocompleteRuntime.php
+++ b/src/Twig/AutocompleteRuntime.php
@@ -23,6 +23,7 @@ final class AutocompleteRuntime implements RuntimeExtensionInterface
         private readonly string $searchKey,
         private readonly string $container,
         private readonly string $placeholder,
+        private readonly int $limit,
         /** @var list<Index> $indexes */
         private readonly array $indexes,
         private readonly bool $debug,
@@ -49,6 +50,7 @@ final class AutocompleteRuntime implements RuntimeExtensionInterface
                 [
                     'item' => $twig->render('@SetonoSyliusMeilisearchPlugin/autocomplete/templates/item.html.twig'),
                 ],
+                $this->limit,
             );
         }
 

--- a/tests/Unit/DependencyInjection/SetonoSyliusMeilisearchExtensionTest.php
+++ b/tests/Unit/DependencyInjection/SetonoSyliusMeilisearchExtensionTest.php
@@ -135,4 +135,47 @@ final class SetonoSyliusMeilisearchExtensionTest extends AbstractExtensionTestCa
         $this->assertContainerBuilderHasParameter('setono_sylius_meilisearch.search.enabled', true);
         $this->assertContainerBuilderHasService(SearchAction::class);
     }
+
+    /**
+     * @test
+     */
+    public function it_configures_autocomplete_with_default_limit(): void
+    {
+        $this->load([
+            'indexes' => [
+                'products' => [
+                    'document' => ProductDocument::class,
+                    'entities' => [ProductEntity::class],
+                ],
+            ],
+            'autocomplete' => [
+                'enabled' => true,
+                'indexes' => ['products'],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('setono_sylius_meilisearch.autocomplete.limit', 5);
+    }
+
+    /**
+     * @test
+     */
+    public function it_configures_a_custom_autocomplete_limit(): void
+    {
+        $this->load([
+            'indexes' => [
+                'products' => [
+                    'document' => ProductDocument::class,
+                    'entities' => [ProductEntity::class],
+                ],
+            ],
+            'autocomplete' => [
+                'enabled' => true,
+                'indexes' => ['products'],
+                'limit' => 8,
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('setono_sylius_meilisearch.autocomplete.limit', 8);
+    }
 }


### PR DESCRIPTION
Fixes #91

## Problem

`getItems()` in `autocomplete.js` sent no limit, so the number of suggestions per source was whatever `@meilisearch/autocomplete-client` defaults to, with no way to change it from plugin config.

## Changes

- Add `autocomplete.limit` (integer, `min(1)`, default `5`) to `Configuration.php`.
- Set the `setono_sylius_meilisearch.autocomplete.limit` parameter and inject it into `AutocompleteRuntime`.
- Emit it on the `Source` DTO.
- Use it in `getItems()`:

```js
queries: [
    {
        indexName: source.index,
        query,
        params: { hitsPerPage: source.limit },
    },
],
```

A single global option covers the common case; per-source limits can come later if `autocomplete.indexes` ever grows per-index options.

## Tests

Added unit tests for the default (`5`) and a custom limit. `composer phpunit`, `composer analyse`, `composer check-style`, `lint:container` all pass.

---

> [!NOTE]
> Part of the #88 → #97 stack. **Base: `issue-90-encode-query`** (#101).