### PR TITLE
Render autocomplete item image only when present

### DIFF
--- a/src/Resources/views/autocomplete/templates/item.html.twig
+++ b/src/Resources/views/autocomplete/templates/item.html.twig
@@ -1,8 +1,7 @@
 <div class="aa-ItemWrapper">
     <div class="aa-ItemContent">
-        <div class="aa-ItemIcon aa-ItemIcon--alignTop">
-            <img src="${item.image}" alt="${item.name}" width="100"/>{# Notice that _ALL_ tags must have a closing tag or be self closing, so do not remove the slash (/) in this image tag #}
-        </div>
+        {# item.image is nullable (products without an image), so only render the icon when it is set — otherwise the browser shows a broken-image icon. Notice that _ALL_ tags must have a closing tag or be self closing, so do not remove the slash (/) in the image tag #}
+        ${item.image ? html`<div class="aa-ItemIcon aa-ItemIcon--alignTop"><img src="${item.image}" alt="${item.name}" width="100"/></div>` : ''}
         <div class="aa-ItemContentBody">
             <div class="aa-ItemContentTitle">${components.Highlight({hit: item, attribute: 'name'})}</div>
         </div>


### PR DESCRIPTION
Fixes #93

## Problem

`autocomplete/templates/item.html.twig` rendered the image unconditionally:

```html
<img src="${item.image}" alt="${item.name}" width="100"/>
```

`Product::$image` is nullable, so products without images produced `<img src="null">` — a broken-image icon in the dropdown.

## Fix

Wrap the icon in a conditional nested `html`` tagged template so the `<img>` is only rendered when `item.image` is set:

```html
${item.image ? html`<div class="aa-ItemIcon aa-ItemIcon--alignTop"><img src="${item.image}" alt="${item.name}" width="100"/></div>` : ''}
```

`lint:twig` passes.

---

> [!NOTE]
> Part of the #88 → #97 stack. **Base: `issue-92-initial-state-query`** (#103).