### PR TITLE
Close the fluent chain of the autocomplete node in Configuration.php

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -172,6 +172,11 @@ INFO, ToggleableInterface::class, EntityFilterInterface::class, QueryBuilderForD
                             ->defaultValue(5)
                             ->info('The maximum number of suggestions to fetch per autocomplete source')
                             ->min(1)
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
         ;
 
         return $treeBuilder;


### PR DESCRIPTION
Fixes #95

## Problem

The `autocomplete` node in `Configuration.php` ended mid-chain — the last node was followed directly by `;` with no closing `->end()` calls. It worked (the tree builder is already captured), but it was fragile: any node appended after `autocomplete` would silently attach to the wrong parent.

## Fix

Close the chain conventionally: `->end()` for the `limit` node, the autocomplete children, the autocomplete node, the root children, and the root.

Verified `config:dump-reference setono_sylius_meilisearch` still lists `container`, `placeholder`, and `limit` under `autocomplete`; `phpunit`, `analyse`, and `check-style` pass.

---

> [!NOTE]
> Part of the #88 → #97 stack. **Base: `issue-94-compile-templates`** (#105).