### PR TITLE
Extract autocomplete source resolution to a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ setono_sylius_meilisearch:
 
 The server-side indexing and search keep using `server.url`; only the autocomplete widget uses `server.public_url`.
 
+### Per-source item template
+
+Each autocomplete source is resolved by `Meilisearch\Autocomplete\SourceResolverInterface`. The default resolver renders `@SetonoSyliusMeilisearchPlugin/autocomplete/templates/{indexName}/item.html.twig` when that template exists, and otherwise falls back to the shared `@SetonoSyliusMeilisearchPlugin/autocomplete/templates/item.html.twig`. So with multiple indexes (e.g. `products` and `taxons`) you can give each its own template just by creating `templates/taxons/item.html.twig` in your app. Decorate the resolver if you need to control the `urlAttribute` (or anything else) per index.
+
 ## Customizing the JavaScript
 
 The plugin ships two first-party scripts, both served as plain browser JavaScript (no build step). You customize them by defining a global options object **before** the script runs — put the `<script>` that sets it above the plugin's scripts, or in a `javascripts` block that renders earlier. The plugin's scripts are loaded with `defer`, so a normal inline `<script>` in `<head>` or the body runs first.

--- a/src/Meilisearch/Autocomplete/DefaultSourceResolver.php
+++ b/src/Meilisearch/Autocomplete/DefaultSourceResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete;
+
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete\Configuration\Source;
+use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
+use Twig\Environment;
+
+final class DefaultSourceResolver implements SourceResolverInterface
+{
+    public function __construct(
+        private readonly IndexUidResolverInterface $indexUidResolver,
+        private readonly Environment $twig,
+        private readonly int $limit,
+        /** The attribute that holds the URL on any given document. Decorate this resolver to vary it per index. */
+        private readonly string $urlAttribute = 'url',
+    ) {
+    }
+
+    public function resolve(Index $index): Source
+    {
+        return new Source(
+            $index->name,
+            $this->indexUidResolver->resolve($index),
+            $this->urlAttribute,
+            [
+                'item' => $this->twig->render($this->resolveItemTemplate($index)),
+            ],
+            $this->limit,
+        );
+    }
+
+    /**
+     * Resolves the item template for the given index, preferring a per-index override
+     * (autocomplete/templates/{indexName}/item.html.twig) and falling back to the shared template.
+     */
+    private function resolveItemTemplate(Index $index): string
+    {
+        $indexTemplate = sprintf('@SetonoSyliusMeilisearchPlugin/autocomplete/templates/%s/item.html.twig', $index->name);
+
+        if ($this->twig->getLoader()->exists($indexTemplate)) {
+            return $indexTemplate;
+        }
+
+        return '@SetonoSyliusMeilisearchPlugin/autocomplete/templates/item.html.twig';
+    }
+}

--- a/src/Meilisearch/Autocomplete/SourceResolverInterface.php
+++ b/src/Meilisearch/Autocomplete/SourceResolverInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete;
+
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete\Configuration\Source;
+
+interface SourceResolverInterface
+{
+    /**
+     * Resolves the autocomplete source (index uid, url attribute and item template) for the given index.
+     */
+    public function resolve(Index $index): Source;
+}

--- a/src/Resources/config/services/conditional/autocomplete.xml
+++ b/src/Resources/config/services/conditional/autocomplete.xml
@@ -2,15 +2,22 @@
 <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="Setono\SyliusMeilisearchPlugin\Twig\AutocompleteRuntime">
+        <service id="Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete\DefaultSourceResolver">
             <argument type="service" id="Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface"/>
+            <argument type="service" id="twig"/>
+            <argument>%setono_sylius_meilisearch.autocomplete.limit%</argument>
+        </service>
+        <service id="Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete\SourceResolverInterface"
+                 alias="Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete\DefaultSourceResolver"/>
+
+        <service id="Setono\SyliusMeilisearchPlugin\Twig\AutocompleteRuntime">
+            <argument type="service" id="Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete\SourceResolverInterface"/>
             <argument type="service" id="translator"/>
             <argument type="service" id="router"/>
             <argument>%setono_sylius_meilisearch.server.public_url%</argument>
             <argument>%setono_sylius_meilisearch.server.search_key%</argument>
             <argument>%setono_sylius_meilisearch.autocomplete.container%</argument>
             <argument>%setono_sylius_meilisearch.autocomplete.placeholder%</argument>
-            <argument>%setono_sylius_meilisearch.autocomplete.limit%</argument>
             <argument type="collection"/> <!-- Gets set in the extension -->
             <argument>%kernel.debug%</argument>
 

--- a/src/Twig/AutocompleteExtension.php
+++ b/src/Twig/AutocompleteExtension.php
@@ -20,7 +20,7 @@ final class AutocompleteExtension extends AbstractExtension
     {
         return [
             // @phpstan-ignore argument.type (Twig resolves the runtime-class callable at runtime)
-            new TwigFunction('ssm_autocomplete_configuration', [AutocompleteRuntime::class, 'configuration'], ['needs_environment' => true, 'is_safe' => ['html']]),
+            new TwigFunction('ssm_autocomplete_configuration', [AutocompleteRuntime::class, 'configuration'], ['is_safe' => ['html']]),
             new TwigFunction('ssm_autocomplete_enabled', $this->isEnabled(...)),
         ];
     }

--- a/src/Twig/AutocompleteRuntime.php
+++ b/src/Twig/AutocompleteRuntime.php
@@ -6,31 +6,28 @@ namespace Setono\SyliusMeilisearchPlugin\Twig;
 
 use Setono\SyliusMeilisearchPlugin\Config\Index;
 use Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete\Configuration\Configuration;
-use Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete\Configuration\Source;
-use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete\SourceResolverInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Twig\Environment;
 use Twig\Extension\RuntimeExtensionInterface;
 
 final class AutocompleteRuntime implements RuntimeExtensionInterface
 {
     public function __construct(
-        private readonly IndexUidResolverInterface $indexNameResolver,
+        private readonly SourceResolverInterface $sourceResolver,
         private readonly TranslatorInterface $translator,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly string $host,
         private readonly string $searchKey,
         private readonly string $container,
         private readonly string $placeholder,
-        private readonly int $limit,
         /** @var list<Index> $indexes */
         private readonly array $indexes,
         private readonly bool $debug,
     ) {
     }
 
-    public function configuration(Environment $twig): string
+    public function configuration(): string
     {
         $configuration = new Configuration(
             host: $this->host,
@@ -42,16 +39,7 @@ final class AutocompleteRuntime implements RuntimeExtensionInterface
         );
 
         foreach ($this->indexes as $index) {
-            // todo resolving the source should be extracted to a service
-            $configuration->sources[] = new Source(
-                $index->name,
-                $this->indexNameResolver->resolve($index),
-                'url',
-                [
-                    'item' => $twig->render('@SetonoSyliusMeilisearchPlugin/autocomplete/templates/item.html.twig'),
-                ],
-                $this->limit,
-            );
+            $configuration->sources[] = $this->sourceResolver->resolve($index);
         }
 
         return sprintf('<script type="application/json" id="ssm-autocomplete-configuration">%s</script>', json_encode($configuration, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE));

--- a/tests/Unit/Meilisearch/Autocomplete/DefaultSourceResolverTest.php
+++ b/tests/Unit/Meilisearch/Autocomplete/DefaultSourceResolverTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Meilisearch\Autocomplete;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Document\Product;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete\DefaultSourceResolver;
+use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete\DefaultSourceResolver
+ */
+final class DefaultSourceResolverTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private const SHARED_TEMPLATE = '@SetonoSyliusMeilisearchPlugin/autocomplete/templates/item.html.twig';
+
+    private const PRODUCTS_TEMPLATE = '@SetonoSyliusMeilisearchPlugin/autocomplete/templates/products/item.html.twig';
+
+    /**
+     * @test
+     */
+    public function it_resolves_a_source_with_the_shared_template_and_defaults(): void
+    {
+        $index = new Index('products', Product::class, [], new Container());
+
+        $indexUidResolver = $this->prophesize(IndexUidResolverInterface::class);
+        $indexUidResolver->resolve($index)->willReturn('prod__products');
+
+        $twig = new Environment(new ArrayLoader([
+            self::SHARED_TEMPLATE => 'SHARED',
+        ]));
+
+        $resolver = new DefaultSourceResolver($indexUidResolver->reveal(), $twig, 5);
+        $source = $resolver->resolve($index);
+
+        self::assertSame('products', $source->id);
+        self::assertSame('prod__products', $source->index);
+        self::assertSame('url', $source->urlAttribute);
+        self::assertSame(5, $source->limit);
+        self::assertSame(['item' => 'SHARED'], $source->templates);
+    }
+
+    /**
+     * @test
+     */
+    public function it_prefers_a_per_index_template_when_it_exists(): void
+    {
+        $index = new Index('products', Product::class, [], new Container());
+
+        $indexUidResolver = $this->prophesize(IndexUidResolverInterface::class);
+        $indexUidResolver->resolve($index)->willReturn('prod__products');
+
+        $twig = new Environment(new ArrayLoader([
+            self::SHARED_TEMPLATE => 'SHARED',
+            self::PRODUCTS_TEMPLATE => 'PRODUCTS',
+        ]));
+
+        $resolver = new DefaultSourceResolver($indexUidResolver->reveal(), $twig, 5);
+        $source = $resolver->resolve($index);
+
+        self::assertSame(['item' => 'PRODUCTS'], $source->templates);
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_the_configured_url_attribute(): void
+    {
+        $index = new Index('products', Product::class, [], new Container());
+
+        $indexUidResolver = $this->prophesize(IndexUidResolverInterface::class);
+        $indexUidResolver->resolve($index)->willReturn('prod__products');
+
+        $twig = new Environment(new ArrayLoader([
+            self::SHARED_TEMPLATE => 'SHARED',
+        ]));
+
+        $resolver = new DefaultSourceResolver($indexUidResolver->reveal(), $twig, 8, 'slug');
+        $source = $resolver->resolve($index);
+
+        self::assertSame('slug', $source->urlAttribute);
+        self::assertSame(8, $source->limit);
+    }
+}


### PR DESCRIPTION
Fixes #96

## Problem

`AutocompleteRuntime::configuration()` built every `Source` inline with a hardcoded `'url'` attribute and the same `item.html.twig` for **all** configured indexes (there was already a `// todo resolving the source should be extracted to a service`). With more than one autocomplete index (e.g. products + taxons), all sources were forced to share one item template.

## Changes

- Add `Meilisearch\Autocomplete\SourceResolverInterface` (index → `Source`).
- Add `DefaultSourceResolver`, a decoratable service that:
  - resolves the item template per index — `autocomplete/templates/{indexName}/item.html.twig` when it exists, falling back to the shared `autocomplete/templates/item.html.twig`;
  - takes a configurable `urlAttribute` (default `url`) and the global `limit`.
- `AutocompleteRuntime` now delegates to the resolver and no longer needs the Twig environment, so `needs_environment` is dropped from the twig function.

Projects can now decorate/replace `SourceResolverInterface` to customize the template or `urlAttribute` per index.

## Tests

Added `DefaultSourceResolverTest` (shared-template fallback, per-index preference, configured url attribute). `phpunit`, `analyse`, `check-style` and `lint:container` all pass (the resolver injects `twig` via the lazy runtime locator — no circular reference).

---

> [!NOTE]
> Part of the #88 → #97 stack. **Base: `issue-95-close-config-chain`** (#106).