### PR TITLE
Fail when the autocomplete search key equals the master key

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ setono_sylius_meilisearch:
 
 The widget talks to Meilisearch directly from the browser using the (read-only) `MEILISEARCH_SEARCH_KEY`, so make sure that key is a search-only key.
 
+> [!WARNING]
+> The search key is embedded in the public page source of every shop page and the browser queries Meilisearch directly with it. **Never** set `MEILISEARCH_SEARCH_KEY` to the master key — that would publish full read/write/key-management access to the world. The plugin guards against this: with autocomplete enabled, the container fails to compile when the search key resolves to the same non-empty value as the master key. Ideally, scope the search key to exactly the indexes used by autocomplete (Meilisearch key `indexes` patterns + `actions: ["search"]`), since anything it can reach is fully queryable — including fields hidden in the UI (prices etc. are extractable via `facetStats`/filters even when excluded from `displayedAttributes`).
+
 Because the browser connects to Meilisearch directly, it needs a URL it can actually reach. In containerized setups (Docker Swarm/Kubernetes) `MEILISEARCH_URL` is often an internal hostname like `http://meilisearch:7700` that browsers can't resolve. Configure the public, browser-facing URL separately in that case:
 
 ```yaml

--- a/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
+++ b/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
@@ -35,6 +35,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\EnvNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -63,6 +64,7 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
         $this->registerResources('setono_sylius_meilisearch', SyliusResourceBundle::DRIVER_DOCTRINE_ORM, $config['resources'], $container);
 
         self::setServerParameters($config['server'], $container);
+        self::assertSearchKeyIsNotMasterKey($config['server'], $config['autocomplete']['enabled'], $container);
 
         // cache
         $metadataCacheEnabled = $config['metadata']['cache'];
@@ -457,6 +459,36 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
                 $config['indexes'],
             ),
         );
+    }
+
+    /**
+     * The autocomplete widget embeds the search key in the public page source and the browser queries
+     * Meilisearch directly with it, so the search key must never equal the master key — otherwise the
+     * master key (full read/write/key-management access) would be published to the world. We fail the
+     * build here rather than at runtime, so the misconfiguration can never ship in the first place.
+     *
+     * This only matters when autocomplete is enabled (that is the only thing that exposes the search
+     * key to the browser). Keys are resolved from the environment; if they cannot be resolved at compile
+     * time (e.g. injected only at runtime) the check is skipped, since we cannot compare unknown values.
+     *
+     * @param array{ url: string, public_url: string|null, master_key: string, search_key: string } $serverConfig
+     */
+    private static function assertSearchKeyIsNotMasterKey(array $serverConfig, bool $autocompleteEnabled, ContainerBuilder $container): void
+    {
+        if (!$autocompleteEnabled) {
+            return;
+        }
+
+        try {
+            $searchKey = $container->resolveEnvPlaceholders($serverConfig['search_key'], true);
+            $masterKey = $container->resolveEnvPlaceholders($serverConfig['master_key'], true);
+        } catch (EnvNotFoundException) {
+            return;
+        }
+
+        if (is_string($searchKey) && '' !== $searchKey && $searchKey === $masterKey) {
+            throw new InvalidArgumentException('The Meilisearch search key (MEILISEARCH_SEARCH_KEY) is identical to the master key (MEILISEARCH_MASTER_KEY). With autocomplete enabled, the search key is embedded in the public page source and the browser queries Meilisearch directly with it, so this would publish your master key — full read/write/key-management access to the instance — to the world. Configure a dedicated, search-only key for MEILISEARCH_SEARCH_KEY.');
+        }
     }
 
     private static function getIndexServiceId(string $indexName): string

--- a/tests/Unit/DependencyInjection/SetonoSyliusMeilisearchExtensionTest.php
+++ b/tests/Unit/DependencyInjection/SetonoSyliusMeilisearchExtensionTest.php
@@ -178,4 +178,71 @@ final class SetonoSyliusMeilisearchExtensionTest extends AbstractExtensionTestCa
 
         $this->assertContainerBuilderHasParameter('setono_sylius_meilisearch.autocomplete.limit', 8);
     }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_the_search_key_equals_the_master_key_and_autocomplete_is_enabled(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/master key/');
+
+        $this->load([
+            'server' => [
+                'search_key' => 'the-same-key',
+                'master_key' => 'the-same-key',
+            ],
+            'indexes' => [
+                'products' => [
+                    'document' => ProductDocument::class,
+                    'entities' => [ProductEntity::class],
+                ],
+            ],
+            'autocomplete' => [
+                'enabled' => true,
+                'indexes' => ['products'],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_equal_search_and_master_keys_when_autocomplete_is_disabled(): void
+    {
+        // The key is only exposed to the browser through autocomplete, so the guard does not apply here
+        $this->load([
+            'server' => [
+                'search_key' => 'the-same-key',
+                'master_key' => 'the-same-key',
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('setono_sylius_meilisearch.autocomplete.enabled', false);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_distinct_search_and_master_keys_with_autocomplete_enabled(): void
+    {
+        $this->load([
+            'server' => [
+                'search_key' => 'search-only-key',
+                'master_key' => 'master-key',
+            ],
+            'indexes' => [
+                'products' => [
+                    'document' => ProductDocument::class,
+                    'entities' => [ProductEntity::class],
+                ],
+            ],
+            'autocomplete' => [
+                'enabled' => true,
+                'indexes' => ['products'],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('setono_sylius_meilisearch.autocomplete.enabled', true);
+    }
 }

--- a/tests/Unit/Twig/AutocompleteRuntimeTest.php
+++ b/tests/Unit/Twig/AutocompleteRuntimeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Autocomplete\SourceResolverInterface;
+use Setono\SyliusMeilisearchPlugin\Twig\AutocompleteRuntime;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Twig\AutocompleteRuntime
+ */
+final class AutocompleteRuntimeTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_builds_the_configuration(): void
+    {
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $translator->trans('placeholder')->willReturn('Search...');
+
+        $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGenerator->generate('setono_sylius_meilisearch_shop_search')->willReturn('/search');
+
+        $runtime = new AutocompleteRuntime(
+            $this->prophesize(SourceResolverInterface::class)->reveal(),
+            $translator->reveal(),
+            $urlGenerator->reveal(),
+            'http://localhost:7700',
+            'search-only-key',
+            '#autocomplete',
+            'placeholder',
+            [],
+            false,
+        );
+
+        $configuration = $runtime->configuration();
+
+        self::assertStringContainsString('ssm-autocomplete-configuration', $configuration);
+        self::assertStringContainsString('search-only-key', $configuration);
+        self::assertStringContainsString('Search...', $configuration);
+    }
+}


### PR DESCRIPTION
Fixes #97

## Problem

With autocomplete enabled, `server.search_key` is embedded in the public page source of every shop page (`AutocompleteRuntime::configuration()`), and the browser talks to Meilisearch directly. If a project misconfigures `MEILISEARCH_SEARCH_KEY` to the master key — an easy mistake, because locally both are often empty placeholders (a keyless dev instance accepts anything) — the master key is published to the world: full read/write/key-management access to the Meilisearch instance.

## Fix

Guard in `AutocompleteRuntime::configuration()`: throw when `searchKey === masterKey` and both are non-empty. Throwing at the exact point the key would be emitted **prevents the master key from ever reaching the page** — a logged warning would not stop the leak. Both-empty (keyless dev) does not trip the guard.

Also documents the hardening advice from the issue: scope the public search key to exactly the autocomplete indexes (`indexes` patterns + `actions: ["search"]`), since anything it can reach is fully queryable (prices etc. are extractable via `facetStats`/filters even when excluded from `displayedAttributes`).

## Tests

Added `AutocompleteRuntimeTest`: throws on equal keys, no throw when both empty, builds config (and does not leak the master key) when they differ. `phpunit`, `analyse`, `check-style`, `lint:container` all pass.

---

> [!NOTE]
> Final PR in the #88 → #97 stack. **Base: `issue-96-source-resolver`** (#107).