### PR TITLE
Show indexes, metadata, and stats in the Meilisearch profiler panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,10 @@ Note: repeated fixture loads accumulate stale documents in a long-lived local Me
 
 Browser tests for the shop search page and autocomplete widget live in `tests/Application/e2e/*.spec.ts` and run with `(cd tests/Application && yarn e2e)` (single-cell `e2e-tests` job in `build.yaml`). Prerequisites are the same DB/fixtures/index chain as Functional, plus `yarn install && yarn build && bin/console assets:install` and the Symfony CLI. `yarn e2e` auto-starts the app via `e2e/serve.sh`, which resolves `MEILISEARCH_SEARCH_KEY` from the running Meilisearch (the browser queries Meilisearch directly for autocomplete) and runs `symfony serve` in `APP_ENV=test`. The search form is AJAX-driven (`src/Resources/public/js/search.js` swaps the `#search-form` node + `history.pushState`), so specs wait on `toHaveURL(...)` after each interaction. Note: the untracked `.mcp.json` configures the Playwright MCP server for agent-driven browsing — unrelated to this suite.
 
+### Running the test app locally
+
+Serve the app with `symfony serve` from `tests/Application` — not PHP's built-in server (`php -S` can hide real env vars from Symfony Dotenv depending on `variables_order`, so `.env.local` silently wins over exported overrides). `e2e/serve.sh` wraps `symfony serve` for the e2e suite and resolves `MEILISEARCH_SEARCH_KEY` first.
+
 ### Dependency extremes
 
 CI tests both `lowest` and `highest` deps (PHP 8.1/8.2/8.3 × Symfony ~6.4.0). Before pushing dependency-related changes, sanity-check lowest: `composer update --prefer-lowest && composer analyse && composer phpunit`, then restore with `composer update`. Version floors that only matter for this repo's toolchain belong in `require-dev` — never add `conflict` entries for them, since conflicts constrain end users.

--- a/src/DataCollector/MeilisearchDataCollector.php
+++ b/src/DataCollector/MeilisearchDataCollector.php
@@ -6,34 +6,120 @@ namespace Setono\SyliusMeilisearchPlugin\DataCollector;
 
 use Meilisearch\Client;
 use Meilisearch\Contracts\SearchQuery;
+use Setono\SyliusMeilisearchPlugin\Config\IndexRegistryInterface;
 use Setono\SyliusMeilisearchPlugin\Meilisearch\Client\TraceableClient;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScopeProviderInterface;
+use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Webmozart\Assert\Assert;
 
-final class MeilisearchDataCollector extends DataCollector
+/**
+ * @phpstan-type IndexData array{
+ *     document: class-string,
+ *     entities: list<class-string>,
+ *     uids: array<string, array{numberOfDocuments: int|null, isIndexing: bool|null, fieldDistribution: Data}|null>,
+ *     searchableAttributes: list<string>,
+ *     filterableAttributes: list<string>,
+ *     sortableAttributes: list<string>,
+ *     facetableAttributes: list<string>,
+ * }
+ */
+final class MeilisearchDataCollector extends DataCollector implements LateDataCollectorInterface
 {
-    public function __construct(private readonly Client $client)
-    {
+    public function __construct(
+        private readonly Client $client,
+        private readonly IndexRegistryInterface $indexRegistry,
+        private readonly IndexScopeProviderInterface $indexScopeProvider,
+        private readonly IndexUidResolverInterface $indexUidResolver,
+    ) {
     }
 
     public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
-        if (!$this->client instanceof TraceableClient) {
+        $this->data['multiSearchRequests'] = [];
+
+        if ($this->client instanceof TraceableClient) {
+            foreach ($this->client->getMultiSearchRequests() as $multiSearchRequest) {
+                /** @psalm-suppress MixedArrayAssignment */
+                $this->data['multiSearchRequests'][] = [
+                    'queries' => array_map(fn (SearchQuery $query) => $this->cloneVar($query->toArray()), $multiSearchRequest['queries']),
+                    'results' => array_map($this->cloneVar(...), $multiSearchRequest['results']),
+                ];
+            }
+        }
+
+        $indexes = [];
+
+        foreach ($this->indexRegistry->getAll() as $index) {
+            $uids = [];
+
+            try {
+                foreach ($this->indexScopeProvider->getAll($index) as $indexScope) {
+                    $uids[$this->indexUidResolver->resolveFromIndexScope($indexScope)] = null;
+                }
+            } catch (\Throwable) {
+                // enumerating index scopes queries the database, and the profiler should not break if that fails
+            }
+
+            $metadata = $index->metadata();
+
+            $indexes[$index->name] = [
+                'document' => $index->document,
+                'entities' => $index->entities,
+                'uids' => $uids,
+                'searchableAttributes' => $metadata->getSearchableAttributeNames(),
+                'filterableAttributes' => $metadata->getFilterableAttributeNames(),
+                'sortableAttributes' => $metadata->getSortableAttributeNames(),
+                'facetableAttributes' => $metadata->getFacetableAttributeNames(),
+            ];
+        }
+
+        $this->data['indexes'] = $indexes;
+    }
+
+    public function lateCollect(): void
+    {
+        $indexes = $this->getIndexes();
+        if ([] === $indexes) {
             return;
         }
 
-        $this->data['multiSearchRequests'] = [];
+        try {
+            $stats = $this->client->stats();
+        } catch (\Throwable $e) {
+            $this->data['statsError'] = $e->getMessage();
 
-        foreach ($this->client->getMultiSearchRequests() as $multiSearchRequest) {
-            /** @psalm-suppress MixedArrayAssignment */
-            $this->data['multiSearchRequests'][] = [
-                'queries' => array_map(fn (SearchQuery $query) => $this->cloneVar($query->toArray()), $multiSearchRequest['queries']),
-                'results' => array_map($this->cloneVar(...), $multiSearchRequest['results']),
-            ];
+            return;
         }
+
+        $indexStats = $stats['indexes'] ?? [];
+        if (!is_array($indexStats)) {
+            return;
+        }
+
+        foreach ($indexes as $name => $index) {
+            foreach (array_keys($index['uids']) as $uid) {
+                $statsForUid = $indexStats[$uid] ?? null;
+                if (!is_array($statsForUid)) {
+                    continue;
+                }
+
+                $numberOfDocuments = $statsForUid['numberOfDocuments'] ?? null;
+                $isIndexing = $statsForUid['isIndexing'] ?? null;
+
+                $indexes[$name]['uids'][$uid] = [
+                    'numberOfDocuments' => is_int($numberOfDocuments) ? $numberOfDocuments : null,
+                    'isIndexing' => is_bool($isIndexing) ? $isIndexing : null,
+                    'fieldDistribution' => $this->cloneVar($statsForUid['fieldDistribution'] ?? []),
+                ];
+            }
+        }
+
+        $this->data['indexes'] = $indexes;
     }
 
     public function getName(): string
@@ -56,6 +142,26 @@ final class MeilisearchDataCollector extends DataCollector
     public function hasMultiSearchRequests(): bool
     {
         return [] !== $this->getMultiSearchRequests();
+    }
+
+    /**
+     * @return array<string, IndexData>
+     */
+    public function getIndexes(): array
+    {
+        /** @var array<string, IndexData> $indexes */
+        $indexes = $this->data['indexes'] ?? [];
+        Assert::isArray($indexes);
+
+        return $indexes;
+    }
+
+    public function getStatsError(): ?string
+    {
+        $statsError = $this->data['statsError'] ?? null;
+        Assert::nullOrString($statsError);
+
+        return $statsError;
     }
 
     public function reset(): void

--- a/src/Resources/config/services/data_collector.xml
+++ b/src/Resources/config/services/data_collector.xml
@@ -4,6 +4,9 @@
     <services>
         <service id="Setono\SyliusMeilisearchPlugin\DataCollector\MeilisearchDataCollector">
             <argument type="service" id="Meilisearch\Client"/>
+            <argument type="service" id="setono_sylius_meilisearch.config.index_registry"/>
+            <argument type="service" id="Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScopeProviderInterface"/>
+            <argument type="service" id="Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface"/>
 
             <tag name="data_collector" template="@SetonoSyliusMeilisearchPlugin/data_collector/meilisearch.html.twig" id="meilisearch"/>
         </service>

--- a/src/Resources/views/data_collector/meilisearch.html.twig
+++ b/src/Resources/views/data_collector/meilisearch.html.twig
@@ -14,6 +14,10 @@
             <b>Multi Search Requests</b>
             <span class="sf-toolbar-status">{{ multiSearchRequestCount }}</span>
         </div>
+        <div class="sf-toolbar-info-piece">
+            <b>Indexes</b>
+            <span class="sf-toolbar-status">{{ collector.indexes|length }}</span>
+        </div>
     {% endset %}
 
     {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { 'link': true }) }}
@@ -41,7 +45,7 @@
 
 {% block menu %}
     {# This left-hand menu appears when using the full-screen profiler. #}
-    <span class="label{{ collector.hasMultiSearchRequests ? '' : ' disabled' }}">
+    <span class="label">
         <span class="icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="m6.505 18.998l4.434-11.345a4.17 4.17 0 0 1 3.882-2.651h2.674l-4.434 11.345a4.17 4.17 0 0 1-3.883 2.651zm6.505 0l4.434-11.345a4.17 4.17 0 0 1 3.883-2.651H24l-4.434 11.345a4.17 4.17 0 0 1-3.882 2.651zm-13.01 0L4.434 7.653a4.17 4.17 0 0 1 3.882-2.651h2.674L6.556 16.347a4.17 4.17 0 0 1-3.883 2.651z"/></svg></span>
         <strong>Meilisearch</strong>
         {% if collector.hasMultiSearchRequests %}
@@ -79,4 +83,83 @@
             <p>No multi search requests.</p>
         </div>
     {% endif %}
+
+    <h2>Indexes</h2>
+
+    {% if collector.statsError %}
+        <div class="empty">
+            <p>Could not fetch stats from Meilisearch: {{ collector.statsError }}</p>
+        </div>
+    {% endif %}
+
+    {% for name, index in collector.indexes %}
+        <h3>{{ name }}</h3>
+
+        <table>
+            <thead>
+                <tr>
+                    <th colspan="2">Configuration</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <th>Document</th>
+                    <td>{{ index.document }}</td>
+                </tr>
+                <tr>
+                    <th>Entities</th>
+                    <td>{{ index.entities|join(', ') }}</td>
+                </tr>
+                <tr>
+                    <th>Searchable attributes</th>
+                    <td>{{ index.searchableAttributes|join(', ') }}</td>
+                </tr>
+                <tr>
+                    <th>Filterable attributes</th>
+                    <td>{{ index.filterableAttributes|join(', ') }}</td>
+                </tr>
+                <tr>
+                    <th>Sortable attributes</th>
+                    <td>{{ index.sortableAttributes|join(', ') }}</td>
+                </tr>
+                <tr>
+                    <th>Facetable attributes</th>
+                    <td>{{ index.facetableAttributes|join(', ') }}</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <table>
+            <thead>
+                <tr>
+                    <th>Index uid</th>
+                    <th>Documents</th>
+                    <th>Indexing?</th>
+                    <th>Field distribution</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for uid, stats in index.uids %}
+                    <tr>
+                        <td>{{ uid }}</td>
+                        {% if stats is null %}
+                            <td colspan="3">{{ collector.statsError ? 'Unknown (stats unavailable)' : 'Not found in Meilisearch' }}</td>
+                        {% else %}
+                            <td>{{ stats.numberOfDocuments ?? 'n/a' }}</td>
+                            <td>{{ stats.isIndexing is null ? 'n/a' : (stats.isIndexing ? 'yes' : 'no') }}</td>
+                            <td>{{ profiler_dump(stats.fieldDistribution, maxDepth=1) }}</td>
+                        {% endif %}
+                    </tr>
+                {% else %}
+                    <tr>
+                        <td colspan="4">No index uids resolved</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <div class="empty empty-panel">
+            <p>No indexes configured.</p>
+        </div>
+    {% endfor %}
 {% endblock %}

--- a/tests/Unit/DataCollector/MeilisearchDataCollectorTest.php
+++ b/tests/Unit/DataCollector/MeilisearchDataCollectorTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\DataCollector;
+
+use Meilisearch\Client;
+use Meilisearch\Contracts\SearchQuery;
+use Nyholm\Psr7\Response as HttpResponse;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Config\IndexRegistry;
+use Setono\SyliusMeilisearchPlugin\DataCollector\MeilisearchDataCollector;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactory;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactoryInterface;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Client\TraceableClient;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScopeProviderInterface;
+use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
+use Setono\SyliusMeilisearchPlugin\Tests\Unit\Document\Metadata\Document;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\VarDumper\Cloner\Data;
+
+final class MeilisearchDataCollectorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private const UID = 'test__products__fashion_web__en_us__usd';
+
+    /**
+     * @test
+     */
+    public function it_collects_index_configuration(): void
+    {
+        $collector = $this->createCollector($this->prophesize(Client::class)->reveal());
+        $collector->collect(new Request(), new Response());
+
+        self::assertFalse($collector->hasMultiSearchRequests());
+        self::assertNull($collector->getStatsError());
+
+        $indexes = $collector->getIndexes();
+        self::assertArrayHasKey('products', $indexes);
+
+        $index = $indexes['products'];
+        self::assertSame(Document::class, $index['document']);
+        self::assertSame([], $index['entities']);
+        self::assertSame([self::UID => null], $index['uids']);
+        self::assertSame(['name'], $index['searchableAttributes']);
+        self::assertSame(['size', 'price', 'taxons', 'collection', 'brand'], $index['filterableAttributes']);
+        self::assertSame(['price'], $index['sortableAttributes']);
+        self::assertSame(['size', 'price', 'collection', 'brand'], $index['facetableAttributes']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_collects_stats_for_resolved_uids(): void
+    {
+        $client = $this->prophesize(Client::class);
+        $client->stats()->willReturn([
+            'databaseSize' => 123,
+            'indexes' => [
+                self::UID => [
+                    'numberOfDocuments' => 10,
+                    'isIndexing' => false,
+                    'fieldDistribution' => ['name' => 10],
+                ],
+            ],
+        ]);
+
+        $collector = $this->createCollector($client->reveal());
+        $collector->collect(new Request(), new Response());
+        $collector->lateCollect();
+
+        self::assertNull($collector->getStatsError());
+
+        $stats = $collector->getIndexes()['products']['uids'][self::UID];
+        self::assertNotNull($stats);
+        self::assertSame(10, $stats['numberOfDocuments']);
+        self::assertFalse($stats['isIndexing']);
+        self::assertInstanceOf(Data::class, $stats['fieldDistribution']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_stores_error_when_stats_request_fails(): void
+    {
+        $client = $this->prophesize(Client::class);
+        $client->stats()->willThrow(new \RuntimeException('Connection refused'));
+
+        $collector = $this->createCollector($client->reveal());
+        $collector->collect(new Request(), new Response());
+        $collector->lateCollect();
+
+        self::assertSame('Connection refused', $collector->getStatsError());
+        self::assertSame([self::UID => null], $collector->getIndexes()['products']['uids']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_collects_multi_search_requests(): void
+    {
+        $httpClient = $this->prophesize(ClientInterface::class);
+        $httpClient->sendRequest(Argument::type(RequestInterface::class))->willReturn(new HttpResponse(
+            200,
+            ['content-type' => 'application/json'],
+            (string) json_encode(['results' => [['indexUid' => self::UID, 'hits' => []]]]),
+        ));
+
+        $client = new TraceableClient('http://localhost:7700', 'masterKey', $httpClient->reveal());
+        $client->multiSearch([(new SearchQuery())->setIndexUid(self::UID)->setQuery('hat')]);
+
+        $collector = new MeilisearchDataCollector(
+            $client,
+            new IndexRegistry(),
+            $this->prophesize(IndexScopeProviderInterface::class)->reveal(),
+            $this->prophesize(IndexUidResolverInterface::class)->reveal(),
+        );
+        $collector->collect(new Request(), new Response());
+
+        self::assertTrue($collector->hasMultiSearchRequests());
+
+        $multiSearchRequests = $collector->getMultiSearchRequests();
+        self::assertCount(1, $multiSearchRequests);
+        self::assertCount(1, $multiSearchRequests[0]['queries']);
+        self::assertCount(1, $multiSearchRequests[0]['results']);
+    }
+
+    private function createCollector(Client $client): MeilisearchDataCollector
+    {
+        $eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(Argument::any())->willReturnArgument();
+
+        $container = new Container();
+        $container->set(MetadataFactoryInterface::class, new MetadataFactory($eventDispatcher->reveal()));
+
+        $index = new Index('products', Document::class, [], $container);
+
+        $indexRegistry = new IndexRegistry();
+        $indexRegistry->add($index);
+
+        $indexScopeProvider = $this->prophesize(IndexScopeProviderInterface::class);
+        $indexScopeProvider->getAll($index)->willReturn([new IndexScope($index, 'FASHION_WEB', 'en_US', 'USD')]);
+
+        $indexUidResolver = $this->prophesize(IndexUidResolverInterface::class);
+        $indexUidResolver->resolveFromIndexScope(Argument::type(IndexScope::class))->willReturn(self::UID);
+
+        return new MeilisearchDataCollector(
+            $client,
+            $indexRegistry,
+            $indexScopeProvider->reveal(),
+            $indexUidResolver->reveal(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Completes the remaining checkbox of #78 ("Display indexes and related documents and metadata") — the multi-search request/response tracing already landed earlier.

- `MeilisearchDataCollector` now also collects every configured index from the `IndexRegistry`: document class, entity classes, all scoped index uids (via `IndexScopeProviderInterface::getAll()` + `IndexUidResolverInterface`), and the document metadata attribute lists (searchable/filterable/sortable/facetable). This section works with the plain client — only multi-search tracing still requires the debug-only `TraceableClient`.
- The collector implements `LateDataCollectorInterface`: `lateCollect()` makes a single `GET /stats` call and maps `numberOfDocuments`, `isIndexing`, and `fieldDistribution` onto each resolved uid. Any failure is caught and stored as `statsError`, so an unreachable Meilisearch renders a warning in the panel instead of a 500.
- The profiler template gets an "Indexes" section (configuration table + per-uid stats table), an "Indexes" toolbar piece, and the menu item is no longer disabled when there are no multi-search requests (the panel always has index data now).
- CLAUDE.md: note to use `symfony serve` (not `php -S`) when serving the test app locally.

## Test plan

- [x] `composer fix-style`, `composer analyse` (PHPStan level max), `vendor/bin/rector process --dry-run` — all clean
- [x] `vendor/bin/phpunit --testsuite Unit` — 38 tests incl. 4 new ones covering index config collection, stats mapping, the stats-failure path, and multi-search collection through a real `TraceableClient` with a mocked PSR-18 client
- [x] `(cd tests/Application && bin/console lint:container && bin/console lint:twig ../../src/Resources/views/data_collector/meilisearch.html.twig)`
- [x] Manual: dev server against a fresh Meilisearch v1.49 + fixtures — panel shows 9 multi-search pairs plus both indexes with correct uids, document counts (21 products / 11 taxons), attribute metadata, and field distribution; with Meilisearch stopped, pages stay 200 and the panel shows the stats warning

Closes #78