### PR TITLE
Add `ssm_search_widget` Twig function to render the search widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,16 @@ class Product extends BaseProduct implements IndexableInterface, FilterableInter
 
 The plugin also ships default entity filters (e.g. an `enabled` filter for `ToggleableInterface` entities and a channel filter for channel-aware entities). Toggle them per index under `indexes.<name>.default_filters`, or add your own by implementing `Filter\Entity\EntityFilterInterface`.
 
+## The search widget
+
+The search widget is automatically injected into the shop header via the `sylius.shop.layout.header.grid` Sylius UI event. If your theme doesn't render that event — or you want the widget somewhere else — render it manually:
+
+```twig
+{{ ssm_search_widget() }}
+```
+
+Depending on your configuration it renders either the javascript based autocomplete widget or a plain search form, and it outputs nothing when both search and autocomplete are disabled.
+
 ## Autocomplete
 
 Enable the instant-search widget and point it at one or more indexes:

--- a/src/Resources/views/search_widget/widget.html.twig
+++ b/src/Resources/views/search_widget/widget.html.twig
@@ -1,6 +1,7 @@
 {#
-    This template is automatically injected using the sylius_ui events system. Depending on your configuration,
-    it will either render the javascript based autocomplete widget or a plain input search field.
+    This template is automatically injected using the sylius_ui events system, but can also be rendered
+    manually anywhere using {{ ssm_search_widget() }}. Depending on your configuration, it will either
+    render the javascript based autocomplete widget or a plain input search field.
 #}
 {% if ssm_autocomplete_enabled() %}
     <div class="ui center aligned column">

--- a/src/Twig/SearchExtension.php
+++ b/src/Twig/SearchExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Setono\SyliusMeilisearchPlugin\Twig;
 
+use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -23,11 +24,20 @@ final class SearchExtension extends AbstractExtension
     {
         return [
             new TwigFunction('ssm_search_enabled', $this->isEnabled(...)),
+            new TwigFunction('ssm_search_widget', $this->renderWidget(...), [
+                'needs_environment' => true,
+                'is_safe' => ['html'],
+            ]),
         ];
     }
 
     public function isEnabled(): bool
     {
         return $this->enabled;
+    }
+
+    public function renderWidget(Environment $twig): string
+    {
+        return $twig->render('@SetonoSyliusMeilisearchPlugin/search_widget/widget.html.twig');
     }
 }

--- a/tests/Unit/Twig/SearchExtensionTest.php
+++ b/tests/Unit/Twig/SearchExtensionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusMeilisearchPlugin\Twig\AutocompleteExtension;
+use Setono\SyliusMeilisearchPlugin\Twig\SearchExtension;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Loader\ChainLoader;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFunction;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Twig\SearchExtension
+ */
+final class SearchExtensionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_renders_the_autocomplete_container_when_autocomplete_is_enabled(): void
+    {
+        self::assertStringContainsString('<div id="autocomplete">', self::render(searchEnabled: true, autocompleteEnabled: true));
+    }
+
+    /**
+     * @test
+     */
+    public function it_renders_the_search_form_when_only_search_is_enabled(): void
+    {
+        self::assertStringContainsString('[fragment: /setono_sylius_meilisearch_shop_search_widget]', self::render(searchEnabled: true, autocompleteEnabled: false));
+    }
+
+    /**
+     * @test
+     */
+    public function it_renders_nothing_when_search_and_autocomplete_are_disabled(): void
+    {
+        self::assertSame('', trim(self::render(searchEnabled: false, autocompleteEnabled: false)));
+    }
+
+    private static function render(bool $searchEnabled, bool $autocompleteEnabled): string
+    {
+        $pluginLoader = new FilesystemLoader();
+        $pluginLoader->addPath(__DIR__ . '/../../../src/Resources/views', 'SetonoSyliusMeilisearchPlugin');
+
+        $twig = new Environment(new ChainLoader([
+            new ArrayLoader(['test.html.twig' => '{{ ssm_search_widget() }}']),
+            $pluginLoader,
+        ]));
+        $twig->addExtension(new SearchExtension($searchEnabled));
+        $twig->addExtension(new AutocompleteExtension($autocompleteEnabled));
+
+        // stubs for the functions normally provided by symfony/twig-bridge
+        $twig->addFunction(new TwigFunction('path', static fn (string $name): string => '/' . $name));
+        $twig->addFunction(new TwigFunction('render', static fn (string $uri): string => sprintf('[fragment: %s]', $uri), ['is_safe' => ['html']]));
+
+        return $twig->render('test.html.twig');
+    }
+}


### PR DESCRIPTION
Resolves #55

Adds a `ssm_search_widget` Twig function so the search widget can be rendered anywhere with:

```twig
{{ ssm_search_widget() }}
```

instead of manually including `@SetonoSyliusMeilisearchPlugin/search_widget/widget.html.twig`.

## Changes

- **`src/Twig/SearchExtension.php`**: registers the `ssm_search_widget` function, rendering the existing widget template. Uses Twig's `needs_environment` option, so no new service/runtime registration is needed (the extension is already registered unconditionally), and `is_safe: html` so the output isn't escaped. The template itself no-ops when both search and autocomplete are disabled, so the function is always safe to call.
- **`src/Resources/views/search_widget/widget.html.twig`**: the leading comment now mentions manual rendering alongside the sylius_ui auto-injection (which stays untouched — no BC break).
- **`README.md`**: new "The search widget" section documenting the function.
- **`tests/Unit/Twig/SearchExtensionTest.php`**: real-render unit test covering all three template branches (autocomplete enabled, only search enabled, both disabled).

## Verification

- `composer analyse` (PHPStan level max) ✅
- `composer check-style` (ECS) ✅
- `composer phpunit` — 53 tests incl. 3 new ✅
- `vendor/bin/rector process --dry-run` ✅
- `composer validate --strict && composer normalize --dry-run` ✅
- `(cd tests/Application && bin/console lint:container)` ✅