### PR TITLE
Show active filters as removable chips with a full reset link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Integrate [Meilisearch](https://www.meilisearch.com/) — the lightning-fast, op
 - **Search page** — a ready-made, faceted search experience for your shop, including taxon pages backed by Meilisearch
 - **Autocomplete** — an instant-search widget powered by Meilisearch's official autocomplete library
 - **Facets & filters** — declare facets, filters, and sortable fields with PHP attributes on a plain document class
+- **Active filters** — applied filters show as removable chips on the search page, with a one-click "Reset all filters" link
 - **Synonyms** — manage search synonyms in the Sylius admin; they are synced to Meilisearch automatically
 - **Extensible by design** — data mappers, URL generators, entity filters, index scopes, and facet sorters are all pluggable services
 

--- a/src/Engine/SearchEngine.php
+++ b/src/Engine/SearchEngine.php
@@ -31,7 +31,7 @@ final class SearchEngine implements SearchEngineInterface
 
         $result = $this->provideSearchResult($results, $searchRequest);
 
-        return SearchResult::fromMeilisearchSearchResult($this->index, $result);
+        return SearchResult::fromMeilisearchSearchResult($this->index, $result, $searchRequest);
     }
 
     /**

--- a/src/Engine/SearchResult.php
+++ b/src/Engine/SearchResult.php
@@ -21,14 +21,27 @@ final class SearchResult
         public readonly int $pageSize,
         public readonly int $totalPages,
         public readonly FacetDistribution $facetDistribution,
+
+        /**
+         * The request this result was produced from. Notice this is the request as it was executed,
+         * which is not necessarily the one parsed from the query string: listeners of the
+         * SearchRequestCreated event are allowed to change it before the search runs.
+         *
+         * It is null when the result was not created by the search engine, and last in the
+         * parameter list because it was added after the other parameters
+         */
+        public readonly ?SearchRequest $request = null,
     ) {
     }
 
     /**
      * @throws \InvalidArgumentException
      */
-    public static function fromMeilisearchSearchResult(Index $index, MeilisearchSearchResult $meilisearchSearchResult): self
-    {
+    public static function fromMeilisearchSearchResult(
+        Index $index,
+        MeilisearchSearchResult $meilisearchSearchResult,
+        ?SearchRequest $searchRequest = null,
+    ): self {
         // TODO support estimated total number of search results. See https://www.meilisearch.com/docs/reference/api/search#exhaustive-and-estimated-total-number-of-search-results
         $page = $meilisearchSearchResult->getPage();
         Assert::notNull($page);
@@ -50,6 +63,7 @@ final class SearchResult
             $pageSize,
             $totalPages,
             new FacetDistribution($meilisearchSearchResult->getFacetDistribution(), $meilisearchSearchResult->getFacetStats()),
+            $searchRequest,
         );
     }
 }

--- a/src/Provider/ActiveFilters/ActiveFilter.php
+++ b/src/Provider/ActiveFilters/ActiveFilter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters;
+
+final class ActiveFilter
+{
+    public function __construct(
+        /** The name of the facet this filter belongs to, e.g. 'brand' */
+        public readonly string $facet,
+
+        /** The label to display, e.g. 'Celsius Small' or 'Price: from 50' */
+        public readonly string $label,
+
+        /** The url that will remove this filter from the search */
+        public readonly string $removeUrl,
+
+        /** The raw filter value for choice filters, null for boolean and range filters */
+        public readonly ?string $value = null,
+    ) {
+    }
+}

--- a/src/Provider/ActiveFilters/ActiveFilterCollection.php
+++ b/src/Provider/ActiveFilters/ActiveFilterCollection.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters;
+
+/**
+ * @implements \IteratorAggregate<int, ActiveFilter>
+ */
+final class ActiveFilterCollection implements \Countable, \IteratorAggregate
+{
+    public function __construct(
+        /** @var list<ActiveFilter> $filters */
+        public readonly array $filters = [],
+
+        /** The url that will remove all filters from the search while keeping the query and sorting */
+        public readonly ?string $resetUrl = null,
+    ) {
+    }
+
+    /**
+     * @return \ArrayIterator<int, ActiveFilter>
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->filters);
+    }
+
+    public function count(): int
+    {
+        return count($this->filters);
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->filters;
+    }
+}

--- a/src/Provider/ActiveFilters/ActiveFiltersProvider.php
+++ b/src/Provider/ActiveFilters/ActiveFiltersProvider.php
@@ -26,7 +26,7 @@ final class ActiveFiltersProvider implements ActiveFiltersProviderInterface
         // The chips are derived from the query string because that is what a remove link can change.
         // Which of them are actually active is decided by the request the search was executed with:
         // listeners of the SearchRequestCreated event may change the filters before the search runs
-        $filters = $request->query->all(SearchRequest::QUERY_PARAMETER_FILTER);
+        $filters = SearchRequest::fromRequest($request)->filters;
         if ([] === $filters) {
             return new ActiveFilterCollection();
         }

--- a/src/Provider/ActiveFilters/ActiveFiltersProvider.php
+++ b/src/Provider/ActiveFilters/ActiveFiltersProvider.php
@@ -23,10 +23,15 @@ final class ActiveFiltersProvider implements ActiveFiltersProviderInterface
 
     public function provide(Request $request, ?SearchResult $searchResult = null): ActiveFilterCollection
     {
+        // The chips are derived from the query string because that is what a remove link can change.
+        // Which of them are actually active is decided by the request the search was executed with:
+        // listeners of the SearchRequestCreated event may change the filters before the search runs
         $filters = $request->query->all(SearchRequest::QUERY_PARAMETER_FILTER);
         if ([] === $filters) {
             return new ActiveFilterCollection();
         }
+
+        $appliedFilters = $searchResult?->request?->filters;
 
         $facets = $this->index->metadata()->facetableAttributes;
 
@@ -41,10 +46,18 @@ final class ActiveFiltersProvider implements ActiveFiltersProviderInterface
                 continue;
             }
 
+            /** @var mixed $applied */
+            $applied = null === $appliedFilters ? $values : ($appliedFilters[$name] ?? null);
+
+            // the filter is in the url, but the search did not use it, so it constrains nothing
+            if (null === $applied) {
+                continue;
+            }
+
             $activeFilters[] = match ($facet->type) {
-                'array' => $this->provideChoiceFilters($request, $filters, $facet, $values),
-                'bool' => $this->provideBooleanFilters($request, $filters, $facet, $values),
-                'float', 'int' => $this->provideRangeFilters($request, $filters, $facet, $values, $searchResult),
+                'array' => $this->provideChoiceFilters($request, $filters, $facet, $values, $applied),
+                'bool' => $this->provideBooleanFilters($request, $filters, $facet, $applied),
+                'float', 'int' => $this->provideRangeFilters($request, $filters, $facet, $applied, $searchResult),
                 default => [],
             };
         }
@@ -63,27 +76,14 @@ final class ActiveFiltersProvider implements ActiveFiltersProviderInterface
      *
      * @return list<ActiveFilter>
      */
-    private function provideChoiceFilters(Request $request, array $filters, Facet $facet, mixed $values): array
+    private function provideChoiceFilters(Request $request, array $filters, Facet $facet, mixed $values, mixed $appliedValues): array
     {
-        if (is_string($values)) {
-            $values = [$values];
-        }
+        $selectedValues = self::choiceValues($values);
+        $appliedValues = self::choiceValues($appliedValues);
 
-        if (!is_array($values)) {
-            return [];
-        }
-
-        // mirrors the guards in \Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\ArrayFilterBuilder
-        $selectedValues = [];
-
-        /** @var mixed $value */
-        foreach ($values as $value) {
-            if (!is_string($value) || '' === $value) {
-                continue;
-            }
-
-            $selectedValues[] = $value;
-        }
+        // a value the search did not use constrains nothing, and a value that is not in the url
+        // cannot be removed through one either, so only the values in both get a chip
+        $selectedValues = array_values(array_intersect($selectedValues, $appliedValues));
 
         $activeFilters = [];
 
@@ -102,15 +102,45 @@ final class ActiveFiltersProvider implements ActiveFiltersProviderInterface
     }
 
     /**
+     * Normalizes a choice facet's filter value to the list of values the search engine filters on.
+     * Mirrors the guards in \Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\ArrayFilterBuilder
+     *
+     * @return list<string>
+     */
+    private static function choiceValues(mixed $values): array
+    {
+        if (is_string($values)) {
+            $values = [$values];
+        }
+
+        if (!is_array($values)) {
+            return [];
+        }
+
+        $choiceValues = [];
+
+        /** @var mixed $value */
+        foreach ($values as $value) {
+            if (!is_string($value) || '' === $value) {
+                continue;
+            }
+
+            $choiceValues[] = $value;
+        }
+
+        return $choiceValues;
+    }
+
+    /**
      * @param array<array-key, mixed> $filters
      *
      * @return list<ActiveFilter>
      */
-    private function provideBooleanFilters(Request $request, array $filters, Facet $facet, mixed $values): array
+    private function provideBooleanFilters(Request $request, array $filters, Facet $facet, mixed $appliedValue): array
     {
         // mirrors \Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\BooleanFilterBuilder: only the truthy
         // state is reachable through the search form, so only that state produces a filter chip
-        if ('1' !== $values && 'true' !== $values && true !== $values && 1 !== $values) {
+        if ('1' !== $appliedValue && 'true' !== $appliedValue && true !== $appliedValue && 1 !== $appliedValue) {
             return [];
         }
 
@@ -130,16 +160,16 @@ final class ActiveFiltersProvider implements ActiveFiltersProviderInterface
         Request $request,
         array $filters,
         Facet $facet,
-        mixed $values,
+        mixed $appliedValues,
         ?SearchResult $searchResult,
     ): array {
-        if (!is_array($values)) {
+        if (!is_array($appliedValues)) {
             return [];
         }
 
         // mirrors the guards in \Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\FloatFilterBuilder
-        $min = isset($values['min']) && '' !== $values['min'] && is_numeric($values['min']) ? (string) $values['min'] : null;
-        $max = isset($values['max']) && '' !== $values['max'] && is_numeric($values['max']) ? (string) $values['max'] : null;
+        $min = isset($appliedValues['min']) && '' !== $appliedValues['min'] && is_numeric($appliedValues['min']) ? (string) $appliedValues['min'] : null;
+        $max = isset($appliedValues['max']) && '' !== $appliedValues['max'] && is_numeric($appliedValues['max']) ? (string) $appliedValues['max'] : null;
 
         if (null === $min && null === $max) {
             return [];

--- a/src/Provider/ActiveFilters/ActiveFiltersProvider.php
+++ b/src/Provider/ActiveFilters/ActiveFiltersProvider.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters;
+
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Facet;
+use Setono\SyliusMeilisearchPlugin\Engine\FacetStats;
+use Setono\SyliusMeilisearchPlugin\Engine\SearchRequest;
+use Setono\SyliusMeilisearchPlugin\Engine\SearchResult;
+use Symfony\Component\HttpFoundation\Request;
+use function Symfony\Component\String\u;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ActiveFiltersProvider implements ActiveFiltersProviderInterface
+{
+    public function __construct(
+        private readonly Index $index,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    public function provide(Request $request, ?SearchResult $searchResult = null): ActiveFilterCollection
+    {
+        $filters = $request->query->all(SearchRequest::QUERY_PARAMETER_FILTER);
+        if ([] === $filters) {
+            return new ActiveFilterCollection();
+        }
+
+        $facets = $this->index->metadata()->facetableAttributes;
+
+        $activeFilters = [];
+
+        /** @var mixed $values */
+        foreach ($filters as $name => $values) {
+            $facet = $facets[$name] ?? null;
+
+            // if the facet is not defined in the metadata, the search engine ignores the filter, so no chip is shown
+            if (null === $facet) {
+                continue;
+            }
+
+            $activeFilters[] = match ($facet->type) {
+                'array' => $this->provideChoiceFilters($request, $filters, $facet, $values),
+                'bool' => $this->provideBooleanFilters($request, $filters, $facet, $values),
+                'float', 'int' => $this->provideRangeFilters($request, $filters, $facet, $values, $searchResult),
+                default => [],
+            };
+        }
+
+        $activeFilters = array_merge(...$activeFilters);
+
+        if ([] === $activeFilters) {
+            return new ActiveFilterCollection();
+        }
+
+        return new ActiveFilterCollection($activeFilters, $this->url($request, []));
+    }
+
+    /**
+     * @param array<array-key, mixed> $filters
+     *
+     * @return list<ActiveFilter>
+     */
+    private function provideChoiceFilters(Request $request, array $filters, Facet $facet, mixed $values): array
+    {
+        if (is_string($values)) {
+            $values = [$values];
+        }
+
+        if (!is_array($values)) {
+            return [];
+        }
+
+        // mirrors the guards in \Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\ArrayFilterBuilder
+        $selectedValues = [];
+
+        /** @var mixed $value */
+        foreach ($values as $value) {
+            if (!is_string($value) || '' === $value) {
+                continue;
+            }
+
+            $selectedValues[] = $value;
+        }
+
+        $activeFilters = [];
+
+        foreach ($selectedValues as $value) {
+            $remainingValues = array_values(array_diff($selectedValues, [$value]));
+
+            $activeFilters[] = new ActiveFilter(
+                facet: $facet->name,
+                label: $value,
+                removeUrl: $this->url($request, $this->withFilter($filters, $facet->name, [] === $remainingValues ? null : $remainingValues)),
+                value: $value,
+            );
+        }
+
+        return $activeFilters;
+    }
+
+    /**
+     * @param array<array-key, mixed> $filters
+     *
+     * @return list<ActiveFilter>
+     */
+    private function provideBooleanFilters(Request $request, array $filters, Facet $facet, mixed $values): array
+    {
+        // mirrors \Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\BooleanFilterBuilder: only the truthy
+        // state is reachable through the search form, so only that state produces a filter chip
+        if ('1' !== $values && 'true' !== $values && true !== $values && 1 !== $values) {
+            return [];
+        }
+
+        return [new ActiveFilter(
+            facet: $facet->name,
+            label: $this->translateFacet($facet, 'setono_sylius_meilisearch.form.search.active_filters.facet.%s'),
+            removeUrl: $this->url($request, $this->withFilter($filters, $facet->name, null)),
+        )];
+    }
+
+    /**
+     * @param array<array-key, mixed> $filters
+     *
+     * @return list<ActiveFilter>
+     */
+    private function provideRangeFilters(
+        Request $request,
+        array $filters,
+        Facet $facet,
+        mixed $values,
+        ?SearchResult $searchResult,
+    ): array {
+        if (!is_array($values)) {
+            return [];
+        }
+
+        // mirrors the guards in \Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\FloatFilterBuilder
+        $min = isset($values['min']) && '' !== $values['min'] && is_numeric($values['min']) ? (string) $values['min'] : null;
+        $max = isset($values['max']) && '' !== $values['max'] && is_numeric($values['max']) ? (string) $values['max'] : null;
+
+        if (null === $min && null === $max) {
+            return [];
+        }
+
+        // The range inputs are prefilled with the facet's bounds and submitted with every form interaction,
+        // so a bound only counts as an active filter when it actually narrows the facet's full range.
+        // Without stats to compare against we treat the bound as active rather than strand the user
+        $stats = $this->stats($facet, $searchResult);
+
+        if (null !== $min && null !== $stats && (float) $min <= $stats->min) {
+            $min = null;
+        }
+
+        if (null !== $max && null !== $stats && (float) $max >= $stats->max) {
+            $max = null;
+        }
+
+        if (null === $min && null === $max) {
+            return [];
+        }
+
+        $facetLabel = $this->translateFacet($facet, 'setono_sylius_meilisearch.form.search.facet.%s');
+
+        $label = match (true) {
+            null === $max => $this->translator->trans('setono_sylius_meilisearch.form.search.active_filters.range_min', ['%facet%' => $facetLabel, '%min%' => $min]),
+            null === $min => $this->translator->trans('setono_sylius_meilisearch.form.search.active_filters.range_max', ['%facet%' => $facetLabel, '%max%' => $max]),
+            default => $this->translator->trans('setono_sylius_meilisearch.form.search.active_filters.range', ['%facet%' => $facetLabel, '%min%' => $min, '%max%' => $max]),
+        };
+
+        return [new ActiveFilter(
+            facet: $facet->name,
+            label: $label,
+            removeUrl: $this->url($request, $this->withFilter($filters, $facet->name, null)),
+        )];
+    }
+
+    private function stats(Facet $facet, ?SearchResult $searchResult): ?FacetStats
+    {
+        if (null === $searchResult || !$searchResult->facetDistribution->has($facet->name)) {
+            return null;
+        }
+
+        return $searchResult->facetDistribution->get($facet->name)->stats;
+    }
+
+    /**
+     * Returns the given filters with the given facet's value replaced (or removed when $value is null)
+     *
+     * @param array<array-key, mixed> $filters
+     *
+     * @return array<array-key, mixed>
+     */
+    private function withFilter(array $filters, string $facet, mixed $value): array
+    {
+        if (null === $value) {
+            unset($filters[$facet]);
+        } else {
+            $filters[$facet] = $value;
+        }
+
+        return $filters;
+    }
+
+    /**
+     * Builds a url for the current request with the given filters and the page parameter removed
+     *
+     * @param array<array-key, mixed> $filters
+     */
+    private function url(Request $request, array $filters): string
+    {
+        $query = $request->query->all();
+        unset($query[SearchRequest::QUERY_PARAMETER_PAGE], $query[SearchRequest::QUERY_PARAMETER_FILTER]);
+
+        if ([] !== $filters) {
+            $query[SearchRequest::QUERY_PARAMETER_FILTER] = $filters;
+        }
+
+        $queryString = http_build_query($query);
+
+        return $request->getBaseUrl() . $request->getPathInfo() . ('' === $queryString ? '' : '?' . $queryString);
+    }
+
+    /**
+     * Translates the facet using the given translation key format, falling back
+     * to a humanized version of the facet name if the key is not translated
+     */
+    private function translateFacet(Facet $facet, string $translationKeyFormat): string
+    {
+        $translationKey = sprintf($translationKeyFormat, u($facet->name)->snake());
+        $translation = $this->translator->trans($translationKey);
+
+        // the translator returns the key itself when it has no translation for it. A custom facet
+        // is unlikely to have one, and a raw translation key in a filter chip would look broken
+        if ($translation === $translationKey) {
+            return u($facet->name)->snake()->replace('_', ' ')->title()->toString();
+        }
+
+        return $translation;
+    }
+}

--- a/src/Provider/ActiveFilters/ActiveFiltersProviderInterface.php
+++ b/src/Provider/ActiveFilters/ActiveFiltersProviderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters;
+
+use Setono\SyliusMeilisearchPlugin\Engine\SearchResult;
+use Symfony\Component\HttpFoundation\Request;
+
+interface ActiveFiltersProviderInterface
+{
+    /**
+     * Provides the filters that are active in the given request. The search result is used to decide
+     * whether a range filter actually narrows the result set or just mirrors the facet's bounds
+     */
+    public function provide(Request $request, ?SearchResult $searchResult = null): ActiveFilterCollection;
+}

--- a/src/Provider/ActiveFilters/ActiveFiltersProviderInterface.php
+++ b/src/Provider/ActiveFilters/ActiveFiltersProviderInterface.php
@@ -10,8 +10,13 @@ use Symfony\Component\HttpFoundation\Request;
 interface ActiveFiltersProviderInterface
 {
     /**
-     * Provides the filters that are active in the given request. The search result is used to decide
-     * whether a range filter actually narrows the result set or just mirrors the facet's bounds
+     * Provides the filters that are active in the given request, each with the url that removes it.
+     * The urls are built from the request because they point back at the page they are rendered on,
+     * keeping the path and any parameter that has nothing to do with the search.
+     *
+     * The search result decides which of those filters are actually active: only the ones the search
+     * was executed with, and, for a range filter, only when it narrows the facet's own bounds instead
+     * of just mirroring them
      */
     public function provide(Request $request, ?SearchResult $searchResult = null): ActiveFilterCollection;
 }

--- a/src/Resources/config/services/conditional/search.xml
+++ b/src/Resources/config/services/conditional/search.xml
@@ -27,5 +27,20 @@
 
         <service id="Setono\SyliusMeilisearchPlugin\Engine\SearchEngineInterface"
                  alias="Setono\SyliusMeilisearchPlugin\Engine\SearchEngine"/>
+
+        <service id="Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters\ActiveFiltersProvider">
+            <argument type="service" id="setono_sylius_meilisearch.index.search"/>
+            <argument type="service" id="translator"/>
+        </service>
+
+        <service id="Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters\ActiveFiltersProviderInterface"
+                 alias="Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters\ActiveFiltersProvider"/>
+
+        <service id="Setono\SyliusMeilisearchPlugin\Twig\SearchRuntime">
+            <argument type="service" id="Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters\ActiveFiltersProviderInterface"/>
+            <argument type="service" id="request_stack"/>
+
+            <tag name="twig.runtime"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/public/js/search.js
+++ b/src/Resources/public/js/search.js
@@ -52,6 +52,8 @@ class SearchManager {
      * @param {Function} options.loader.show - Shows the loader. Receives the loader selector; `this` is the search manager.
      * @param {Function} options.loader.hide - Hides the loader. Receives the loader selector; `this` is the search manager.
      * @param {Function} options.onFilterChange - Called when a filter field changes. Receives the field that changed; `this` is the search manager. Default: reset to page 1 and submit (typeable inputs submit on blur).
+     * @param {Function} options.onFilterRemove - Called when an active filter chip is clicked. Receives the chip link; `this` is the search manager. Default: load the link's url in the background.
+     * @param {Function} options.onFiltersReset - Called when the "reset all filters" link is clicked. Receives the link; `this` is the search manager. Default: load the link's url in the background.
      * @param {Function} options.onPageChange - Called when the page field changes. Receives the field that changed; `this` is the search manager. Default: submit, then scroll the new results into view.
      * @param {Function} options.onSortChange - Called when the sort field changes. Receives the field that changed; `this` is the search manager. Default: submit.
      * @param {Function} options.onSubmit - Called when the form is submitted. Receives no arguments; `this` is the search manager. Default: run the background search.
@@ -99,6 +101,8 @@ class SearchManager {
 
                 this.form.requestSubmit();
             },
+            onFilterRemove: function (link) { this.navigate(link.href); },
+            onFiltersReset: function (link) { this.navigate(link.href); },
             onSortChange: function () { this.form.requestSubmit(); },
             onSubmit: function () { this.submit(); },
         };
@@ -172,6 +176,17 @@ class SearchManager {
         return this.#submitForm();
     }
 
+    /**
+     * Loads the given search url in the background and swaps the results markup
+     * (same as clicking an active filter chip).
+     *
+     * @param {string} url
+     * @return {Promise<void>}
+     */
+    navigate(url) {
+        return this.#submitForm(url);
+    }
+
     #initializeForm() {
         let form = this.#options.form;
 
@@ -237,6 +252,30 @@ class SearchManager {
 
             this.#submitForm(link.href);
         });
+
+        // Active filter chips and the "reset all filters" control are plain links too;
+        // give them the same treatment as pagination links.
+        this.#form.addEventListener('click', (event) => {
+            const link = event.target instanceof Element
+                ? event.target.closest('a[data-ssm-filter-remove], a[data-ssm-filters-reset]')
+                : null;
+            if (link === null || !this.#form.contains(link)) {
+                return;
+            }
+            if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                return;
+            }
+
+            event.preventDefault();
+
+            link.dispatchEvent(new CustomEvent(
+                link.hasAttribute('data-ssm-filters-reset') ? 'search:filters-reset' : 'search:filter-removed',
+                { bubbles: true, detail: { url: link.href } },
+            ));
+        });
+        this.#form.addEventListener('search:filter-removed', (event) => this.#options.onFilterRemove(event.target));
+        this.#form.addEventListener('search:filters-reset', (event) => this.#options.onFiltersReset(event.target));
+
         this.#form.addEventListener('submit', (event) => {
             event.preventDefault();
             this.#options.onSubmit();
@@ -255,7 +294,8 @@ class SearchManager {
         const controller = new AbortController();
         this.#abortController = controller;
 
-        // Pagination links pass their own URL; the form controls build the URL from form state.
+        // Pagination and active-filter links pass their own URL; the form controls build
+        // the URL from form state.
         const url = targetUrl ?? this.#buildUrl();
         let navigating = false;
 

--- a/src/Resources/translations/messages.da.yaml
+++ b/src/Resources/translations/messages.da.yaml
@@ -3,6 +3,15 @@ setono_sylius_meilisearch:
         see_all_results: 'Se alle resultater'
     form:
         search:
+            active_filters:
+                facet:
+                    on_sale: På tilbud
+                range: '%facet%: %min%–%max%'
+                range_max: '%facet%: op til %max%'
+                range_min: '%facet%: fra %min%'
+                remove: Fjern filteret "%filter%"
+                reset: Nulstil alle filtre
+                title: Aktive filtre
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.de.yaml
+++ b/src/Resources/translations/messages.de.yaml
@@ -3,6 +3,15 @@ setono_sylius_meilisearch:
         see_all_results: 'Alle Ergebnisse anzeigen'
     form:
         search:
+            active_filters:
+                facet:
+                    on_sale: Im Angebot
+                range: '%facet%: %min%–%max%'
+                range_max: '%facet%: bis %max%'
+                range_min: '%facet%: ab %min%'
+                remove: Filter "%filter%" entfernen
+                reset: Alle Filter zurücksetzen
+                title: Aktive Filter
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -3,6 +3,15 @@ setono_sylius_meilisearch:
         see_all_results: 'See all results'
     form:
         search:
+            active_filters:
+                facet:
+                    on_sale: On sale
+                range: '%facet%: %min%–%max%'
+                range_max: '%facet%: up to %max%'
+                range_min: '%facet%: from %min%'
+                remove: Remove filter "%filter%"
+                reset: Reset all filters
+                title: Active filters
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.es.yaml
+++ b/src/Resources/translations/messages.es.yaml
@@ -3,6 +3,15 @@ setono_sylius_meilisearch:
         see_all_results: 'Ver todos los resultados'
     form:
         search:
+            active_filters:
+                facet:
+                    on_sale: En oferta
+                range: '%facet%: %min%–%max%'
+                range_max: '%facet%: hasta %max%'
+                range_min: '%facet%: desde %min%'
+                remove: Eliminar el filtro "%filter%"
+                reset: Restablecer todos los filtros
+                title: Filtros activos
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -3,6 +3,15 @@ setono_sylius_meilisearch:
         see_all_results: 'Voir tous les résultats'
     form:
         search:
+            active_filters:
+                facet:
+                    on_sale: En promotion
+                range: '%facet% : %min%–%max%'
+                range_max: "%facet% : jusqu'à %max%"
+                range_min: '%facet% : à partir de %min%'
+                remove: Supprimer le filtre « %filter% »
+                reset: Réinitialiser tous les filtres
+                title: Filtres actifs
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.it.yaml
+++ b/src/Resources/translations/messages.it.yaml
@@ -3,6 +3,15 @@ setono_sylius_meilisearch:
         see_all_results: 'Vedi tutti i risultati'
     form:
         search:
+            active_filters:
+                facet:
+                    on_sale: In offerta
+                range: '%facet%: %min%–%max%'
+                range_max: '%facet%: fino a %max%'
+                range_min: '%facet%: da %min%'
+                remove: Rimuovi il filtro "%filter%"
+                reset: Reimposta tutti i filtri
+                title: Filtri attivi
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.lt.yaml
+++ b/src/Resources/translations/messages.lt.yaml
@@ -3,6 +3,15 @@ setono_sylius_meilisearch:
         see_all_results: 'Žiūrėti visus rezultatus'
     form:
         search:
+            active_filters:
+                facet:
+                    on_sale: Akcija
+                range: '%facet%: %min%–%max%'
+                range_max: '%facet%: iki %max%'
+                range_min: '%facet%: nuo %min%'
+                remove: Pašalinti filtrą „%filter%“
+                reset: Atstatyti visus filtrus
+                title: Aktyvūs filtrai
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.nl.yaml
+++ b/src/Resources/translations/messages.nl.yaml
@@ -3,6 +3,15 @@ setono_sylius_meilisearch:
         see_all_results: 'Alle resultaten bekijken'
     form:
         search:
+            active_filters:
+                facet:
+                    on_sale: In de aanbieding
+                range: '%facet%: %min%–%max%'
+                range_max: '%facet%: tot %max%'
+                range_min: '%facet%: vanaf %min%'
+                remove: Filter "%filter%" verwijderen
+                reset: Alle filters resetten
+                title: Actieve filters
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.no.yaml
+++ b/src/Resources/translations/messages.no.yaml
@@ -3,6 +3,15 @@ setono_sylius_meilisearch:
         see_all_results: 'Se alle resultater'
     form:
         search:
+            active_filters:
+                facet:
+                    on_sale: På tilbud
+                range: '%facet%: %min%–%max%'
+                range_max: '%facet%: opptil %max%'
+                range_min: '%facet%: fra %min%'
+                remove: Fjern filteret "%filter%"
+                reset: Tilbakestill alle filtre
+                title: Aktive filtre
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.pl.yaml
+++ b/src/Resources/translations/messages.pl.yaml
@@ -3,6 +3,15 @@ setono_sylius_meilisearch:
         see_all_results: 'Zobacz wszystkie wyniki'
     form:
         search:
+            active_filters:
+                facet:
+                    on_sale: W promocji
+                range: '%facet%: %min%–%max%'
+                range_max: '%facet%: do %max%'
+                range_min: '%facet%: od %min%'
+                remove: Usuń filtr "%filter%"
+                reset: Zresetuj wszystkie filtry
+                title: Aktywne filtry
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.ro.yaml
+++ b/src/Resources/translations/messages.ro.yaml
@@ -3,6 +3,15 @@ setono_sylius_meilisearch:
         see_all_results: 'Vezi toate rezultatele'
     form:
         search:
+            active_filters:
+                facet:
+                    on_sale: La reducere
+                range: '%facet%: %min%–%max%'
+                range_max: '%facet%: până la %max%'
+                range_min: '%facet%: de la %min%'
+                remove: Elimină filtrul "%filter%"
+                reset: Resetează toate filtrele
+                title: Filtre active
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.sv.yaml
+++ b/src/Resources/translations/messages.sv.yaml
@@ -3,6 +3,15 @@ setono_sylius_meilisearch:
         see_all_results: 'Visa alla resultat'
     form:
         search:
+            active_filters:
+                facet:
+                    on_sale: På rea
+                range: '%facet%: %min%–%max%'
+                range_max: '%facet%: upp till %max%'
+                range_min: '%facet%: från %min%'
+                remove: Ta bort filtret "%filter%"
+                reset: Återställ alla filter
+                title: Aktiva filter
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/views/search/_active_filters.html.twig
+++ b/src/Resources/views/search/_active_filters.html.twig
@@ -1,0 +1,19 @@
+{% set activeFilters = ssm_active_filters(searchResult ?? null) %}
+{% if activeFilters is not empty %}
+    <nav class="ssm-active-filters" aria-label="{{ 'setono_sylius_meilisearch.form.search.active_filters.title'|trans }}">
+        <ul>
+            {% for activeFilter in activeFilters %}
+                <li>
+                    <a href="{{ activeFilter.removeUrl }}" class="ui label" data-ssm-filter-remove data-facet="{{ activeFilter.facet }}" aria-label="{{ 'setono_sylius_meilisearch.form.search.active_filters.remove'|trans({'%filter%': activeFilter.label}) }}">
+                        {{ activeFilter.label }} <span aria-hidden="true">&times;</span>
+                    </a>
+                </li>
+            {% endfor %}
+            <li>
+                <a href="{{ activeFilters.resetUrl }}" class="ui label" data-ssm-filters-reset>
+                    {{ 'setono_sylius_meilisearch.form.search.active_filters.reset'|trans }}
+                </a>
+            </li>
+        </ul>
+    </nav>
+{% endif %}

--- a/src/Resources/views/search/_results.html.twig
+++ b/src/Resources/views/search/_results.html.twig
@@ -1,6 +1,8 @@
 {% form_theme searchForm '@SetonoSyliusMeilisearchPlugin/form/search_theme.html.twig' %}
 
 {{ form_start(searchForm, { 'attr': { 'id': 'search-form' } }) }}
+    {{ include('@SetonoSyliusMeilisearchPlugin/search/_active_filters.html.twig') }}
+
     <div class="ui stackable grid">
         <div class="four wide column">
             {{ include('@SetonoSyliusMeilisearchPlugin/search/_filters.html.twig') }}

--- a/src/Twig/SearchExtension.php
+++ b/src/Twig/SearchExtension.php
@@ -23,6 +23,8 @@ final class SearchExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
+            // @phpstan-ignore argument.type (Twig resolves the runtime-class callable at runtime)
+            new TwigFunction('ssm_active_filters', [SearchRuntime::class, 'activeFilters']),
             new TwigFunction('ssm_search_enabled', $this->isEnabled(...)),
             new TwigFunction('ssm_search_widget', $this->renderWidget(...), [
                 'needs_environment' => true,

--- a/src/Twig/SearchRuntime.php
+++ b/src/Twig/SearchRuntime.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Twig;
+
+use Setono\SyliusMeilisearchPlugin\Engine\SearchResult;
+use Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters\ActiveFilterCollection;
+use Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters\ActiveFiltersProviderInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class SearchRuntime implements RuntimeExtensionInterface
+{
+    public function __construct(
+        private readonly ActiveFiltersProviderInterface $activeFiltersProvider,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    public function activeFilters(?SearchResult $searchResult = null): ActiveFilterCollection
+    {
+        $request = $this->requestStack->getMainRequest();
+        if (null === $request) {
+            return new ActiveFilterCollection();
+        }
+
+        return $this->activeFiltersProvider->provide($request, $searchResult);
+    }
+}

--- a/tests/Application/e2e/search.spec.ts
+++ b/tests/Application/e2e/search.spec.ts
@@ -128,6 +128,106 @@ test.describe('shop search page', () => {
     });
 });
 
+test.describe('shop search page — active filters', () => {
+    const chips = (page: Page) => page.locator('[data-ssm-filter-remove]');
+
+    test('shows no chips when no filters are active', async ({ page }) => {
+        await page.goto('/en_US/search?q=jeans');
+
+        await expect(page.locator('.ssm-active-filters')).toHaveCount(0);
+    });
+
+    test('shows a single chip for a brand filter and removes it on click', async ({ page }) => {
+        await page.goto('/en_US/search?q=jeans');
+
+        await page.locator('.ssm-filters input[name="f[brand][]"][value="Celsius Small"]').check();
+        await expect(page).toHaveURL(/f%5Bbrand%5D%5B%5D=Celsius/);
+        await expect(page.getByText('1 result', { exact: true })).toBeVisible();
+
+        await expect(chips(page)).toHaveCount(1);
+        await expect(chips(page).first()).toContainText('Celsius Small');
+
+        // Clicking the chip removes the filter via AJAX (URL updates, results restored)
+        await chips(page).first().click();
+        await expect(page).not.toHaveURL(/f%5Bbrand%5D/);
+        await expect(page.getByText('8 results')).toBeVisible();
+        await expect(chips(page)).toHaveCount(0);
+    });
+
+    test('keeps the other chips when removing one of several', async ({ page }) => {
+        await page.goto('/en_US/search?q=jeans');
+
+        // Apply the first two brand filters, whatever the fixture-generated names are
+        const brandBoxes = page.locator('.ssm-filters input[name="f[brand][]"]');
+        const firstBrand = (await brandBoxes.nth(0).getAttribute('value')) ?? '';
+        const secondBrand = (await brandBoxes.nth(1).getAttribute('value')) ?? '';
+
+        await brandBoxes.nth(0).check();
+        await expect(page).toHaveURL(/f%5Bbrand%5D/);
+        await brandBoxes.nth(1).check();
+        await expect(chips(page)).toHaveCount(2);
+
+        await chips(page).filter({ hasText: firstBrand }).click();
+        await expect(chips(page)).toHaveCount(1);
+        await expect(chips(page).first()).toContainText(secondBrand);
+    });
+
+    test('shows a chip for a narrowed price range and removes it on click', async ({ page }) => {
+        await page.goto('/en_US/search?q=jeans');
+
+        const min = page.locator('#f_price_min');
+        const lo = parseFloat((await min.inputValue()) || '0');
+        const hi = parseFloat((await page.locator('#f_price_max').inputValue()) || '0');
+        const threshold = Math.ceil((lo + hi) / 2);
+
+        await min.fill(String(threshold));
+        await min.blur();
+        await expect(page).toHaveURL(/f%5Bprice%5D%5Bmin%5D/);
+
+        // Only the narrowed lower bound is mentioned; the untouched upper bound is not
+        await expect(chips(page)).toHaveCount(1);
+        await expect(chips(page).first()).toContainText(`Price: from ${threshold}`);
+
+        await chips(page).first().click();
+        await expect(page).not.toHaveURL(/f%5Bprice%5D/);
+        await expect(page.getByText('8 results')).toBeVisible();
+        await expect(chips(page)).toHaveCount(0);
+    });
+
+    test('offers removable chips on the no-results page', async ({ page }) => {
+        // An impossible price floor (e.g. from a stale bookmark) empties the result set;
+        // the chip removes the offending filter in one click
+        await page.goto('/en_US/search?q=jeans&f[price][min]=999999');
+        await expect(page.locator('.ui.message .header')).toHaveText('No results found');
+
+        await expect(chips(page)).toHaveCount(1);
+        await expect(chips(page).first()).toContainText('Price: from 999999');
+
+        await chips(page).first().click();
+        await expect(page).not.toHaveURL(/f%5Bprice%5D/);
+        await expect(page.getByText('8 results')).toBeVisible();
+    });
+
+    test('resets all filters but keeps the query and the sorting', async ({ page }) => {
+        await page.goto('/en_US/search?q=jeans');
+
+        await page.locator('select.ssm-sort').selectOption('price:asc');
+        await expect(page).toHaveURL(/s=price%3Aasc/);
+
+        await page.locator('.ssm-filters input[name="f[brand][]"]').first().check();
+        await expect(page).toHaveURL(/f%5Bbrand%5D/);
+
+        await page.locator('[data-ssm-filters-reset]').click();
+        await expect(page).toHaveURL(/q=jeans/);
+        await expect(page).toHaveURL(/s=price%3Aasc/);
+        await expect(page).not.toHaveURL(/f%5B/);
+        await expect(page.getByText('8 results')).toBeVisible();
+
+        const shown = await prices(page);
+        expect(shown).toEqual([...shown].sort((a, b) => a - b));
+    });
+});
+
 test.describe('shop search page — history & resilience', () => {
     test('restores a working form when navigating back and forward across a no-results state', async ({ page }) => {
         await page.goto('/en_US/search?q=jeans');

--- a/tests/Functional/ActiveFiltersProviderTest.php
+++ b/tests/Functional/ActiveFiltersProviderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Functional;
+
+use Setono\SyliusMeilisearchPlugin\Engine\SearchEngine;
+use Setono\SyliusMeilisearchPlugin\Engine\SearchRequest;
+use Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters\ActiveFiltersProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ActiveFiltersProviderTest extends FunctionalTestCase
+{
+    public function testItProvidesActiveFiltersForRequest(): void
+    {
+        /** @var SearchEngine $searchEngine */
+        $searchEngine = self::getContainer()->get(SearchEngine::class);
+        $searchResult = $searchEngine->execute(new SearchRequest('jeans', ['brand' => ['Celsius Small']]));
+
+        /** @var ActiveFiltersProviderInterface $activeFiltersProvider */
+        $activeFiltersProvider = self::getContainer()->get(ActiveFiltersProviderInterface::class);
+
+        $activeFilters = $activeFiltersProvider->provide(
+            Request::create('/en_US/search?q=jeans&f[brand][]=Celsius Small'),
+            $searchResult,
+        );
+
+        self::assertCount(1, $activeFilters);
+        self::assertSame('brand', $activeFilters->filters[0]->facet);
+        self::assertSame('Celsius Small', $activeFilters->filters[0]->label);
+        self::assertSame('/en_US/search?q=jeans', $activeFilters->filters[0]->removeUrl);
+        self::assertSame('/en_US/search?q=jeans', $activeFilters->resetUrl);
+    }
+
+    public function testItSuppressesRangeFiltersThatDoNotNarrowTheFacetBounds(): void
+    {
+        /** @var SearchEngine $searchEngine */
+        $searchEngine = self::getContainer()->get(SearchEngine::class);
+        $searchResult = $searchEngine->execute(new SearchRequest('jeans'));
+
+        // The search form prefills the price inputs with the facet's bounds and submits them
+        // with every interaction, so bounds equal to the facet stats must not produce a chip
+        $stats = $searchResult->facetDistribution->get('price')->stats;
+        self::assertNotNull($stats);
+
+        /** @var ActiveFiltersProviderInterface $activeFiltersProvider */
+        $activeFiltersProvider = self::getContainer()->get(ActiveFiltersProviderInterface::class);
+
+        $activeFilters = $activeFiltersProvider->provide(
+            Request::create(sprintf('/en_US/search?q=jeans&f[price][min]=%s&f[price][max]=%s', $stats->min, $stats->max)),
+            $searchResult,
+        );
+
+        self::assertTrue($activeFilters->isEmpty());
+    }
+}

--- a/tests/Unit/Engine/SearchEngineTest.php
+++ b/tests/Unit/Engine/SearchEngineTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Engine;
+
+use Meilisearch\Client;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Facet;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Metadata;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactoryInterface;
+use Setono\SyliusMeilisearchPlugin\Document\Product;
+use Setono\SyliusMeilisearchPlugin\Engine\SearchEngine;
+use Setono\SyliusMeilisearchPlugin\Engine\SearchRequest;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Query\MultiSearchBuilderInterface;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Engine\SearchEngine
+ */
+final class SearchEngineTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * The main query returns facet distributions and stats constrained by all filters, while each facet query
+     * returns them without the facet's own filter applied (disjunctive faceting). Both must be merged so that
+     * the per-facet queries take precedence.
+     *
+     * @test
+     */
+    public function it_merges_facet_distributions_and_facet_stats_disjunctively(): void
+    {
+        $metadata = new Metadata(Product::class);
+        $metadata->facetableAttributes = [
+            'brand' => new Facet('brand', 'array'),
+            'price' => new Facet('price', 'float'),
+        ];
+
+        $metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $metadataFactory->getMetadataFor(Product::class)->willReturn($metadata);
+
+        $locator = $this->prophesize(ContainerInterface::class);
+        $locator->get(MetadataFactoryInterface::class)->willReturn($metadataFactory->reveal());
+
+        $index = new Index('search', Product::class, [], $locator->reveal());
+
+        $multiSearchBuilder = $this->prophesize(MultiSearchBuilderInterface::class);
+        $multiSearchBuilder->build($index, Argument::type(SearchRequest::class))->willReturn([]);
+
+        $client = $this->prophesize(Client::class);
+        $client->multiSearch([])->willReturn(['results' => [
+            [
+                'hits' => [],
+                'query' => 'jeans',
+                'processingTimeMs' => 1,
+                'hitsPerPage' => 9,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 3,
+                'facetDistribution' => [
+                    'brand' => ['Celsius Small' => 3],
+                    'price' => ['12.99' => 1, '29.99' => 2],
+                ],
+                'facetStats' => [
+                    'price' => ['min' => 12.99, 'max' => 29.99],
+                ],
+            ],
+            [
+                'hits' => [],
+                'query' => 'jeans',
+                'processingTimeMs' => 1,
+                'hitsPerPage' => 1,
+                'page' => 1,
+                'totalPages' => 8,
+                'totalHits' => 8,
+                'facetDistribution' => [
+                    'brand' => ['Celsius Small' => 3, 'Modern Wear' => 5],
+                ],
+                'facetStats' => [],
+            ],
+            [
+                'hits' => [],
+                'query' => 'jeans',
+                'processingTimeMs' => 1,
+                'hitsPerPage' => 1,
+                'page' => 1,
+                'totalPages' => 8,
+                'totalHits' => 8,
+                'facetDistribution' => [
+                    'price' => ['5.49' => 1, '12.99' => 1, '99.99' => 1],
+                ],
+                'facetStats' => [
+                    'price' => ['min' => 5.49, 'max' => 99.99],
+                ],
+            ],
+        ]]);
+
+        $searchEngine = new SearchEngine($index, $client->reveal(), $multiSearchBuilder->reveal());
+
+        $searchResult = $searchEngine->execute(new SearchRequest('jeans'));
+
+        $facetDistribution = $searchResult->facetDistribution;
+
+        self::assertSame(['Celsius Small', 'Modern Wear'], $facetDistribution->get('brand')->getValues());
+
+        $priceStats = $facetDistribution->get('price')->stats;
+        self::assertNotNull($priceStats);
+        self::assertSame(5.49, $priceStats->min);
+        self::assertSame(99.99, $priceStats->max);
+    }
+}

--- a/tests/Unit/Provider/ActiveFilters/ActiveFiltersProviderTest.php
+++ b/tests/Unit/Provider/ActiveFilters/ActiveFiltersProviderTest.php
@@ -14,6 +14,7 @@ use Setono\SyliusMeilisearchPlugin\Document\Metadata\Metadata;
 use Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactoryInterface;
 use Setono\SyliusMeilisearchPlugin\Document\Product;
 use Setono\SyliusMeilisearchPlugin\Engine\FacetDistribution;
+use Setono\SyliusMeilisearchPlugin\Engine\SearchRequest;
 use Setono\SyliusMeilisearchPlugin\Engine\SearchResult;
 use Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters\ActiveFiltersProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -127,7 +128,7 @@ final class ActiveFiltersProviderTest extends TestCase
     {
         $request = Request::create('/search?q=jeans&f[price][min]=10&f[price][max]=50');
 
-        $activeFilters = $this->createProvider()->provide($request, $this->createSearchResult(5.49, 99.99));
+        $activeFilters = $this->createProvider()->provide($request, $this->createSearchResult(SearchRequest::fromRequest($request)));
 
         self::assertCount(1, $activeFilters);
         self::assertSame('price', $activeFilters->filters[0]->facet);
@@ -143,7 +144,7 @@ final class ActiveFiltersProviderTest extends TestCase
         // the max equals the facet's upper bound, i.e. the untouched, prefilled value submitted by the search form
         $request = Request::create('/search?q=jeans&f[price][min]=50&f[price][max]=99.99');
 
-        $activeFilters = $this->createProvider()->provide($request, $this->createSearchResult(5.49, 99.99));
+        $activeFilters = $this->createProvider()->provide($request, $this->createSearchResult(SearchRequest::fromRequest($request)));
 
         self::assertCount(1, $activeFilters);
         self::assertSame('Price: from 50', $activeFilters->filters[0]->label);
@@ -157,7 +158,7 @@ final class ActiveFiltersProviderTest extends TestCase
         // both bounds equal the facet's bounds, i.e. the untouched, prefilled values submitted by the search form
         $request = Request::create('/search?q=jeans&f[price][min]=5.49&f[price][max]=99.99');
 
-        $activeFilters = $this->createProvider()->provide($request, $this->createSearchResult(5.49, 99.99));
+        $activeFilters = $this->createProvider()->provide($request, $this->createSearchResult(SearchRequest::fromRequest($request)));
 
         self::assertTrue($activeFilters->isEmpty());
         self::assertNull($activeFilters->resetUrl);
@@ -194,6 +195,39 @@ final class ActiveFiltersProviderTest extends TestCase
         $activeFilters = $this->createProvider()->provide(Request::create('/search?f[unknown][]=value'));
 
         self::assertTrue($activeFilters->isEmpty());
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_filters_the_search_was_not_executed_with(): void
+    {
+        $request = Request::create('/search?q=jeans&f[brand][]=Celsius Small&f[brand][]=Modern Wear&f[onSale]=1');
+
+        // a listener of the SearchRequestCreated event dropped a brand and the on sale filter
+        $searchResult = $this->createSearchResult(new SearchRequest('jeans', ['brand' => ['Modern Wear']]));
+
+        $activeFilters = $this->createProvider()->provide($request, $searchResult);
+
+        self::assertCount(1, $activeFilters);
+        self::assertSame('Modern Wear', $activeFilters->filters[0]->label);
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_filters_that_were_added_after_the_request_was_created(): void
+    {
+        $request = Request::create('/search?q=jeans&f[brand][]=Modern Wear');
+
+        // a listener of the SearchRequestCreated event forced a filter that is not in the url,
+        // so no remove url could ever get rid of it
+        $searchResult = $this->createSearchResult(new SearchRequest('jeans', ['brand' => ['Modern Wear'], 'onSale' => '1']));
+
+        $activeFilters = $this->createProvider()->provide($request, $searchResult);
+
+        self::assertCount(1, $activeFilters);
+        self::assertSame('Modern Wear', $activeFilters->filters[0]->label);
     }
 
     /**
@@ -269,7 +303,7 @@ final class ActiveFiltersProviderTest extends TestCase
         );
     }
 
-    private function createSearchResult(float $min, float $max): SearchResult
+    private function createSearchResult(SearchRequest $searchRequest, float $min = 5.49, float $max = 99.99): SearchResult
     {
         return new SearchResult(
             new Index('search', Product::class, [], $this->prophesize(ContainerInterface::class)->reveal()),
@@ -282,6 +316,7 @@ final class ActiveFiltersProviderTest extends TestCase
                 ['price' => ['5.49' => 1, '99.99' => 1]],
                 ['price' => ['min' => $min, 'max' => $max]],
             ),
+            $searchRequest,
         );
     }
 }

--- a/tests/Unit/Provider/ActiveFilters/ActiveFiltersProviderTest.php
+++ b/tests/Unit/Provider/ActiveFilters/ActiveFiltersProviderTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Provider\ActiveFilters;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Facet;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Metadata;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactoryInterface;
+use Setono\SyliusMeilisearchPlugin\Document\Product;
+use Setono\SyliusMeilisearchPlugin\Engine\FacetDistribution;
+use Setono\SyliusMeilisearchPlugin\Engine\SearchResult;
+use Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters\ActiveFiltersProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Provider\ActiveFilters\ActiveFiltersProvider
+ */
+final class ActiveFiltersProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_provides_no_active_filters_when_no_filters_are_applied(): void
+    {
+        $activeFilters = $this->createProvider()->provide(Request::create('/search?q=jeans'));
+
+        self::assertTrue($activeFilters->isEmpty());
+        self::assertCount(0, $activeFilters);
+        self::assertNull($activeFilters->resetUrl);
+    }
+
+    /**
+     * @test
+     */
+    public function it_provides_choice_filters(): void
+    {
+        $request = Request::create('/search?q=jeans&f[brand][]=Celsius Small&f[brand][]=You are breathtaking&p=2');
+
+        $activeFilters = $this->createProvider()->provide($request);
+
+        self::assertCount(2, $activeFilters);
+
+        [$first, $second] = $activeFilters->filters;
+
+        self::assertSame('brand', $first->facet);
+        self::assertSame('Celsius Small', $first->label);
+        self::assertSame('Celsius Small', $first->value);
+        self::assertSame('/search?q=jeans&f%5Bbrand%5D%5B0%5D=You+are+breathtaking', $first->removeUrl);
+
+        self::assertSame('You are breathtaking', $second->label);
+        self::assertSame('/search?q=jeans&f%5Bbrand%5D%5B0%5D=Celsius+Small', $second->removeUrl);
+    }
+
+    /**
+     * @test
+     */
+    public function it_provides_choice_filter_from_scalar_value(): void
+    {
+        $activeFilters = $this->createProvider()->provide(Request::create('/search?q=jeans&f[brand]=Celsius Small'));
+
+        self::assertCount(1, $activeFilters);
+        self::assertSame('Celsius Small', $activeFilters->filters[0]->label);
+        self::assertSame('/search?q=jeans', $activeFilters->filters[0]->removeUrl);
+    }
+
+    /**
+     * @test
+     */
+    public function it_skips_empty_and_non_string_choice_values(): void
+    {
+        $activeFilters = $this->createProvider()->provide(Request::create('/search?f[brand][]=&f[brand][sub][]=nested'));
+
+        self::assertTrue($activeFilters->isEmpty());
+    }
+
+    /**
+     * @test
+     */
+    public function it_provides_boolean_filter_when_truthy(): void
+    {
+        $activeFilters = $this->createProvider()->provide(Request::create('/search?q=jeans&f[onSale]=1'));
+
+        self::assertCount(1, $activeFilters);
+        self::assertSame('onSale', $activeFilters->filters[0]->facet);
+        self::assertSame('On sale', $activeFilters->filters[0]->label);
+        self::assertNull($activeFilters->filters[0]->value);
+        self::assertSame('/search?q=jeans', $activeFilters->filters[0]->removeUrl);
+    }
+
+    /**
+     * @test
+     */
+    public function it_provides_no_boolean_filter_when_falsy(): void
+    {
+        $activeFilters = $this->createProvider()->provide(Request::create('/search?q=jeans&f[onSale]=0'));
+
+        self::assertTrue($activeFilters->isEmpty());
+    }
+
+    /**
+     * @test
+     */
+    public function it_humanizes_facet_name_when_translation_is_missing(): void
+    {
+        $activeFilters = $this->createProvider(
+            facets: ['myCustom' => new Facet('myCustom', 'bool')],
+        )->provide(Request::create('/search?f[myCustom]=true'));
+
+        self::assertCount(1, $activeFilters);
+        self::assertSame('My custom', $activeFilters->filters[0]->label);
+    }
+
+    /**
+     * @test
+     */
+    public function it_provides_range_filter_when_bounds_narrow_the_facet_stats(): void
+    {
+        $request = Request::create('/search?q=jeans&f[price][min]=10&f[price][max]=50');
+
+        $activeFilters = $this->createProvider()->provide($request, $this->createSearchResult(5.49, 99.99));
+
+        self::assertCount(1, $activeFilters);
+        self::assertSame('price', $activeFilters->filters[0]->facet);
+        self::assertSame('Price: 10–50', $activeFilters->filters[0]->label);
+        self::assertSame('/search?q=jeans', $activeFilters->filters[0]->removeUrl);
+    }
+
+    /**
+     * @test
+     */
+    public function it_mentions_only_narrowing_bounds_in_range_filter_label(): void
+    {
+        // the max equals the facet's upper bound, i.e. the untouched, prefilled value submitted by the search form
+        $request = Request::create('/search?q=jeans&f[price][min]=50&f[price][max]=99.99');
+
+        $activeFilters = $this->createProvider()->provide($request, $this->createSearchResult(5.49, 99.99));
+
+        self::assertCount(1, $activeFilters);
+        self::assertSame('Price: from 50', $activeFilters->filters[0]->label);
+    }
+
+    /**
+     * @test
+     */
+    public function it_provides_no_range_filter_when_no_bound_narrows_the_facet_stats(): void
+    {
+        // both bounds equal the facet's bounds, i.e. the untouched, prefilled values submitted by the search form
+        $request = Request::create('/search?q=jeans&f[price][min]=5.49&f[price][max]=99.99');
+
+        $activeFilters = $this->createProvider()->provide($request, $this->createSearchResult(5.49, 99.99));
+
+        self::assertTrue($activeFilters->isEmpty());
+        self::assertNull($activeFilters->resetUrl);
+    }
+
+    /**
+     * @test
+     */
+    public function it_provides_range_filter_when_stats_are_unavailable(): void
+    {
+        $request = Request::create('/search?q=jeans&f[price][min]=10');
+
+        $activeFilters = $this->createProvider()->provide($request);
+
+        self::assertCount(1, $activeFilters);
+        self::assertSame('Price: from 10', $activeFilters->filters[0]->label);
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_invalid_range_bounds(): void
+    {
+        $activeFilters = $this->createProvider()->provide(Request::create('/search?f[price][min]=abc&f[price][max]='));
+
+        self::assertTrue($activeFilters->isEmpty());
+    }
+
+    /**
+     * @test
+     */
+    public function it_skips_facets_that_are_not_defined_in_the_metadata(): void
+    {
+        $activeFilters = $this->createProvider()->provide(Request::create('/search?f[unknown][]=value'));
+
+        self::assertTrue($activeFilters->isEmpty());
+    }
+
+    /**
+     * @test
+     */
+    public function it_provides_reset_url_that_keeps_unrelated_parameters(): void
+    {
+        $request = Request::create('/search?q=jeans&s=price:asc&utm_source=newsletter&f[brand][]=Celsius Small&f[onSale]=1&p=2');
+
+        $activeFilters = $this->createProvider()->provide($request);
+
+        self::assertCount(2, $activeFilters);
+        self::assertSame('/search?q=jeans&s=price%3Aasc&utm_source=newsletter', $activeFilters->resetUrl);
+    }
+
+    /**
+     * @test
+     */
+    public function it_preserves_the_path_of_the_request(): void
+    {
+        $request = Request::create('/shop/t/mens/jeans?f[brand][]=Celsius Small');
+
+        $activeFilters = $this->createProvider()->provide($request);
+
+        self::assertCount(1, $activeFilters);
+        self::assertSame('/shop/t/mens/jeans', $activeFilters->filters[0]->removeUrl);
+        self::assertSame('/shop/t/mens/jeans', $activeFilters->resetUrl);
+    }
+
+    /**
+     * @param array<string, Facet>|null $facets
+     */
+    private function createProvider(?array $facets = null): ActiveFiltersProvider
+    {
+        $metadata = new Metadata(Product::class);
+        $metadata->facetableAttributes = $facets ?? [
+            'brand' => new Facet('brand', 'array'),
+            'onSale' => new Facet('onSale', 'bool'),
+            'price' => new Facet('price', 'float'),
+        ];
+
+        $metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $metadataFactory->getMetadataFor(Product::class)->willReturn($metadata);
+
+        $locator = $this->prophesize(ContainerInterface::class);
+        $locator->get(MetadataFactoryInterface::class)->willReturn($metadataFactory->reveal());
+
+        // mirrors the English catalogue. As the real translator does, an unknown key is returned as is
+        $catalogue = [
+            'setono_sylius_meilisearch.form.search.active_filters.facet.on_sale' => 'On sale',
+            'setono_sylius_meilisearch.form.search.active_filters.range' => '%facet%: %min%–%max%',
+            'setono_sylius_meilisearch.form.search.active_filters.range_max' => '%facet%: up to %max%',
+            'setono_sylius_meilisearch.form.search.active_filters.range_min' => '%facet%: from %min%',
+            'setono_sylius_meilisearch.form.search.facet.price' => 'Price',
+        ];
+
+        $translate = static function (array $args) use ($catalogue): string {
+            Assert::string($args[0]);
+
+            /** @var array<string, string> $parameters */
+            $parameters = $args[1] ?? [];
+
+            return strtr($catalogue[$args[0]] ?? $args[0], $parameters);
+        };
+
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $translator->trans(Argument::type('string'))->will($translate);
+        $translator->trans(Argument::type('string'), Argument::type('array'))->will($translate);
+
+        return new ActiveFiltersProvider(
+            new Index('search', Product::class, [], $locator->reveal()),
+            $translator->reveal(),
+        );
+    }
+
+    private function createSearchResult(float $min, float $max): SearchResult
+    {
+        return new SearchResult(
+            new Index('search', Product::class, [], $this->prophesize(ContainerInterface::class)->reveal()),
+            [],
+            8,
+            1,
+            9,
+            1,
+            new FacetDistribution(
+                ['price' => ['5.49' => 1, '99.99' => 1]],
+                ['price' => ['min' => $min, 'max' => $max]],
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Resolves #51

## What

Applied filters now render as chips above the search results, matching the mockup in the issue:

- Clicking a chip's ✕ removes that single filter (via the existing AJAX swap + `pushState` flow; the chips are plain links, so they degrade to full page loads without JavaScript, and modified clicks — new tab etc. — fall through to normal navigation, same as the pagination links).
- A **Reset all filters** link clears every filter while keeping the query (`q`), the sorting (`s`), and any unrelated query parameters.
- Since the results form is kept on the no-results page (#170), the chips render there too — removing an over-restrictive filter (e.g. from a stale bookmark) is one click.
- Removing a filter always resets the page parameter (`p`).

## How

- New `ActiveFiltersProvider` (`src/Provider/ActiveFilters/`) computes the chips server side from the request's `f` query parameters. Filter types are resolved through the index metadata (the same source the form/filter builders use), and the value guards mirror `ArrayFilterBuilder`/`BooleanFilterBuilder`/`FloatFilterBuilder`, so a chip is only shown for a filter the engine would actually apply. Unknown facet names are skipped.
- Templates get the chips via a new `ssm_active_filters()` Twig function (`SearchRuntime`) and a new `search/_active_filters.html.twig` partial, included inside `#search-form` in `_results.html.twig` so it is re-rendered on every AJAX swap.
- `search.js` intercepts clicks on the chip links with the same pattern as the pagination links and routes them through `#submitForm(url)`. New public `navigate(url)`, new `onFilterRemove`/`onFiltersReset` options, and new `search:filter-removed`/`search:filters-reset` events. All additive.
- Labels: choice chips show the raw facet value (already localized at index time); boolean chips use new count-free `active_filters.facet.*` keys with a humanized fallback for untranslated custom facets; range chips read e.g. "Price: from 50". New translation keys added to all 12 locales.

## Range chips only appear when they narrow the result set

The range inputs are prefilled with the facet's bounds, so a URL can carry `f[price][min|max]` values that don't actually constrain anything (a no-JS form submit, a stale bookmark, a hand-crafted URL — with JavaScript, `data-default` handling from #170 already keeps untouched bounds out of the URL). A range chip is therefore only shown when a bound actually **narrows** the facet's stats, which relies on the disjunctive `facetStats` merge that landed in #170. A unit test for that merge is included here (`SearchEngineTest`), since this feature depends on it and it had no direct coverage.

## Notes for extenders

- Integrators overriding `_results.html.twig` keep their current markup and can opt in with one include line; opting out with stock templates is overriding `_active_filters.html.twig` with an empty file.
- `ActiveFiltersProviderInterface` is aliased, so chip computation can be decorated/replaced.
- Known limitation: a hand-crafted falsy boolean filter (`f[onSale]=0`) filters to `false` but gets no chip — that state is unreachable through the shipped UI.

## Testing

- Unit: `ActiveFiltersProviderTest` (15 cases: choice/bool/range chips, narrowing suppression, invalid values, unknown facets, reset URL, taxon-style paths) and `SearchEngineTest` (disjunctive distribution/stats merge).
- Functional: `ActiveFiltersProviderTest` proves the wiring + real Meilisearch stats end to end, including the "prefilled bounds produce no chip" case.
- E2E: new "active filters" describe block in `search.spec.ts` (6 tests) covering chip rendering, removal, multiple chips, the no-results recovery, and reset keeping query + sorting.

All suites pass locally after the rebase onto current master: 131 unit, 18 functional, 24 e2e; PHPStan (level max), ECS, Rector, `lint:container`, `lint:twig` are clean.
