### PR TITLE
Fix swapped sprintf arguments in IndexRegistry::get() exception message

### DIFF
--- a/src/Config/IndexRegistry.php
+++ b/src/Config/IndexRegistry.php
@@ -35,8 +35,8 @@ final class IndexRegistry implements \IteratorAggregate, IndexRegistryInterface
         if (!isset($this->indexes[$name])) {
             throw new \InvalidArgumentException(sprintf(
                 'No index exists with the name %s. Available indexes are: [%s]',
-                implode(', ', array_keys($this->indexes)),
                 $name,
+                implode(', ', array_keys($this->indexes)),
             ));
         }
 

--- a/tests/Unit/Config/IndexRegistryTest.php
+++ b/tests/Unit/Config/IndexRegistryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Config;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Config\IndexRegistry;
+use Setono\SyliusMeilisearchPlugin\Document\Product;
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Config\IndexRegistry
+ */
+final class IndexRegistryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_throws_with_the_requested_and_available_names_in_the_correct_order(): void
+    {
+        $registry = new IndexRegistry();
+        $registry->add(new Index('products', Product::class, [], new Container()));
+        $registry->add(new Index('taxons', Product::class, [], new Container()));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No index exists with the name nope. Available indexes are: [products, taxons]');
+
+        $registry->get('nope');
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_registered_index(): void
+    {
+        $registry = new IndexRegistry();
+        $index = new Index('products', Product::class, [], new Container());
+        $registry->add($index);
+
+        self::assertSame($index, $registry->get('products'));
+    }
+}


### PR DESCRIPTION
## What

`IndexRegistry::get()` built its "index not found" exception with the `sprintf` arguments swapped: the list of available indexes was printed where the requested name should be, and vice versa, producing a misleading message like:

> No index exists with the name products, taxons. Available indexes are: [prodcuts]

This swaps the two arguments so the message reads correctly:

> No index exists with the name nope. Available indexes are: [products, taxons]

## Testing

Added a unit test on the message (`IndexRegistryTest`) to prevent regression.

Closes #118