### PR TITLE
Fix leading backslash breaking EntityUrlGeneratorInterface autowiring

### DIFF
--- a/src/Resources/config/services/url_generator.xml
+++ b/src/Resources/config/services/url_generator.xml
@@ -2,11 +2,11 @@
 <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="\Setono\SyliusMeilisearchPlugin\UrlGenerator\EntityUrlGeneratorInterface"
+        <service id="Setono\SyliusMeilisearchPlugin\UrlGenerator\EntityUrlGeneratorInterface"
                  alias="setono_sylius_meilisearch.url_generator.composite"/>
 
         <service id="setono_sylius_meilisearch.url_generator.composite"
-                 class="\Setono\SyliusMeilisearchPlugin\UrlGenerator\CompositeEntityUrlGenerator"/>
+                 class="Setono\SyliusMeilisearchPlugin\UrlGenerator\CompositeEntityUrlGenerator"/>
 
         <service id="setono_sylius_meilisearch.url_generator.product"
                  class="Setono\SyliusMeilisearchPlugin\UrlGenerator\ProductUrlGenerator">

--- a/tests/Functional/UrlGenerator/EntityUrlGeneratorAutowiringTest.php
+++ b/tests/Functional/UrlGenerator/EntityUrlGeneratorAutowiringTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Functional\UrlGenerator;
+
+use Setono\SyliusMeilisearchPlugin\UrlGenerator\CompositeEntityUrlGenerator;
+use Setono\SyliusMeilisearchPlugin\UrlGenerator\EntityUrlGeneratorInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\UrlGenerator\CompositeEntityUrlGenerator
+ */
+final class EntityUrlGeneratorAutowiringTest extends KernelTestCase
+{
+    /**
+     * The alias id for EntityUrlGeneratorInterface must not carry a leading backslash,
+     * otherwise autowiring (which resolves type-hints to the FQCN without a leading
+     * backslash) never matches the alias.
+     *
+     * @test
+     */
+    public function it_wires_the_interface_to_the_composite_generator(): void
+    {
+        self::bootKernel(['environment' => 'test', 'debug' => true]);
+
+        $container = self::getContainer();
+
+        self::assertTrue($container->has(EntityUrlGeneratorInterface::class));
+        self::assertInstanceOf(
+            CompositeEntityUrlGenerator::class,
+            $container->get(EntityUrlGeneratorInterface::class),
+        );
+    }
+}


### PR DESCRIPTION
## What

The service alias for `EntityUrlGeneratorInterface` was registered with a **leading backslash** in its id (`id="\Setono\...\EntityUrlGeneratorInterface"`). Symfony autowiring resolves type-hints to the FQCN *without* a leading backslash, so the alias never matched — a consumer type-hinting `EntityUrlGeneratorInterface` in their own service got a "cannot autowire" error instead of the composite generator.

The `class` attribute of the composite service definition had the same stray backslash (harmless for instantiation, but inconsistent). Both are removed. A grep of `src/Resources/config/services/*.xml` for `="\` confirms these were the only two occurrences.

## Testing

Added `EntityUrlGeneratorAutowiringTest` (boots the test kernel and asserts `EntityUrlGeneratorInterface` resolves to `CompositeEntityUrlGenerator`). Confirmed it fails before the fix and passes after. `lint:container` also passes.

Closes #119

---
_Stacked on #145 (#118)._