### PR TITLE
Check currencyCode in PriceDataMapper::supports()

### DIFF
--- a/src/DataMapper/Product/PriceDataMapper.php
+++ b/src/DataMapper/Product/PriceDataMapper.php
@@ -57,7 +57,10 @@ final class PriceDataMapper implements DataMapperInterface
      */
     public function supports(IndexableInterface $source, Document $target, IndexScope $indexScope, array $context = []): bool
     {
-        return $source instanceof ProductInterface && $target instanceof ProductDocument && $indexScope->channelCode !== null;
+        return $source instanceof ProductInterface &&
+            $target instanceof ProductDocument &&
+            $indexScope->channelCode !== null &&
+            $indexScope->currencyCode !== null;
     }
 
     private static function getBaseCurrencyCode(ChannelInterface $channel): string

--- a/src/Resources/config/services/url_generator.xml
+++ b/src/Resources/config/services/url_generator.xml
@@ -2,11 +2,11 @@
 <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="\Setono\SyliusMeilisearchPlugin\UrlGenerator\EntityUrlGeneratorInterface"
+        <service id="Setono\SyliusMeilisearchPlugin\UrlGenerator\EntityUrlGeneratorInterface"
                  alias="setono_sylius_meilisearch.url_generator.composite"/>
 
         <service id="setono_sylius_meilisearch.url_generator.composite"
-                 class="\Setono\SyliusMeilisearchPlugin\UrlGenerator\CompositeEntityUrlGenerator"/>
+                 class="Setono\SyliusMeilisearchPlugin\UrlGenerator\CompositeEntityUrlGenerator"/>
 
         <service id="setono_sylius_meilisearch.url_generator.product"
                  class="Setono\SyliusMeilisearchPlugin\UrlGenerator\ProductUrlGenerator">

--- a/tests/Functional/UrlGenerator/EntityUrlGeneratorAutowiringTest.php
+++ b/tests/Functional/UrlGenerator/EntityUrlGeneratorAutowiringTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Functional\UrlGenerator;
+
+use Setono\SyliusMeilisearchPlugin\UrlGenerator\CompositeEntityUrlGenerator;
+use Setono\SyliusMeilisearchPlugin\UrlGenerator\EntityUrlGeneratorInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\UrlGenerator\CompositeEntityUrlGenerator
+ */
+final class EntityUrlGeneratorAutowiringTest extends KernelTestCase
+{
+    /**
+     * The alias id for EntityUrlGeneratorInterface must not carry a leading backslash,
+     * otherwise autowiring (which resolves type-hints to the FQCN without a leading
+     * backslash) never matches the alias.
+     *
+     * @test
+     */
+    public function it_wires_the_interface_to_the_composite_generator(): void
+    {
+        self::bootKernel(['environment' => 'test', 'debug' => true]);
+
+        $container = self::getContainer();
+
+        self::assertTrue($container->has(EntityUrlGeneratorInterface::class));
+        self::assertInstanceOf(
+            CompositeEntityUrlGenerator::class,
+            $container->get(EntityUrlGeneratorInterface::class),
+        );
+    }
+}

--- a/tests/Unit/DataMapper/Product/PriceDataMapperTest.php
+++ b/tests/Unit/DataMapper/Product/PriceDataMapperTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\DataMapper\Product;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\DataMapper\Product\PriceDataMapper;
+use Setono\SyliusMeilisearchPlugin\DataMapper\Product\Provider\ProductPricesProviderInterface;
+use Setono\SyliusMeilisearchPlugin\Document\Product as ProductDocument;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Setono\SyliusMeilisearchPlugin\Tests\Application\Entity\Product;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Currency\Converter\CurrencyConverterInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class PriceDataMapperTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private function createDataMapper(): PriceDataMapper
+    {
+        return new PriceDataMapper(
+            $this->prophesize(ChannelRepositoryInterface::class)->reveal(),
+            $this->prophesize(CurrencyConverterInterface::class)->reveal(),
+            $this->prophesize(ProductPricesProviderInterface::class)->reveal(),
+        );
+    }
+
+    private function createIndexScope(?string $channelCode, ?string $currencyCode): IndexScope
+    {
+        $index = new Index('products', ProductDocument::class, [Product::class], new ContainerBuilder());
+
+        return new IndexScope($index, $channelCode, 'en_US', $currencyCode);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_support_a_scope_without_a_currency(): void
+    {
+        $dataMapper = $this->createDataMapper();
+
+        self::assertFalse($dataMapper->supports(
+            new Product(),
+            new ProductDocument(),
+            $this->createIndexScope('FASHION_WEB', null),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_support_a_scope_without_a_channel(): void
+    {
+        $dataMapper = $this->createDataMapper();
+
+        self::assertFalse($dataMapper->supports(
+            new Product(),
+            new ProductDocument(),
+            $this->createIndexScope(null, 'USD'),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_supports_a_scope_with_both_a_channel_and_a_currency(): void
+    {
+        $dataMapper = $this->createDataMapper();
+
+        self::assertTrue($dataMapper->supports(
+            new Product(),
+            new ProductDocument(),
+            $this->createIndexScope('FASHION_WEB', 'USD'),
+        ));
+    }
+}


### PR DESCRIPTION
## What

`PriceDataMapper::supports()` promised (via `@psalm-assert-if-true`) that `$indexScope->currencyCode` is non-null, but only actually checked `channelCode`. `map()` then passed `$indexScope->currencyCode` into the currency converter, so for any index whose scopes are produced without a currency (e.g. an index served by `DefaultIndexScopeProvider` because its `entities` list isn't exactly the product one) this was a `TypeError` at indexing time.

This adds `null !== $indexScope->currencyCode` to `supports()`, so the psalm assertion is backed by a runtime check and the mapper cleanly skips scopes it cannot price. (`map()` does not dereference `localeCode`, so no locale check is needed.)

## Testing

Added `PriceDataMapperTest` covering `supports()` returning `false` for a channel-but-no-currency scope, `false` for a currency-but-no-channel scope, and `true` when both are present.

Closes #114

---
_Stacked on #146 (#119)._