### PR TITLE
Keep empty arrays in SettingsNormalizer so index settings can be reset

### DIFF
--- a/src/DataMapper/Product/PriceDataMapper.php
+++ b/src/DataMapper/Product/PriceDataMapper.php
@@ -57,7 +57,10 @@ final class PriceDataMapper implements DataMapperInterface
      */
     public function supports(IndexableInterface $source, Document $target, IndexScope $indexScope, array $context = []): bool
     {
-        return $source instanceof ProductInterface && $target instanceof ProductDocument && $indexScope->channelCode !== null;
+        return $source instanceof ProductInterface &&
+            $target instanceof ProductDocument &&
+            $indexScope->channelCode !== null &&
+            $indexScope->currencyCode !== null;
     }
 
     private static function getBaseCurrencyCode(ChannelInterface $channel): string

--- a/src/Normalizer/SettingsNormalizer.php
+++ b/src/Normalizer/SettingsNormalizer.php
@@ -29,13 +29,12 @@ final class SettingsNormalizer implements NormalizerInterface
             throw new LogicException('The normalized settings data must be an array or an ArrayObject');
         }
 
-        return array_filter($data, static function (mixed $value): bool {
-            if (is_array($value)) {
-                return [] !== $value;
-            }
-
-            return null !== $value;
-        });
+        // Only strip null values. Empty arrays are meaningful for list-valued settings
+        // (filterableAttributes, sortableAttributes, stopWords, synonyms, …): because
+        // updateSettings is a *partial* update, sending [] is exactly how you reset such a
+        // setting. Keys that must be omitted when "not configured" are modelled as null in
+        // Settings, not as [].
+        return array_filter($data, static fn (mixed $value): bool => null !== $value);
     }
 
     /**

--- a/tests/Unit/DataMapper/Product/PriceDataMapperTest.php
+++ b/tests/Unit/DataMapper/Product/PriceDataMapperTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\DataMapper\Product;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\DataMapper\Product\PriceDataMapper;
+use Setono\SyliusMeilisearchPlugin\DataMapper\Product\Provider\ProductPricesProviderInterface;
+use Setono\SyliusMeilisearchPlugin\Document\Product as ProductDocument;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Setono\SyliusMeilisearchPlugin\Tests\Application\Entity\Product;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Currency\Converter\CurrencyConverterInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class PriceDataMapperTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private function createDataMapper(): PriceDataMapper
+    {
+        return new PriceDataMapper(
+            $this->prophesize(ChannelRepositoryInterface::class)->reveal(),
+            $this->prophesize(CurrencyConverterInterface::class)->reveal(),
+            $this->prophesize(ProductPricesProviderInterface::class)->reveal(),
+        );
+    }
+
+    private function createIndexScope(?string $channelCode, ?string $currencyCode): IndexScope
+    {
+        $index = new Index('products', ProductDocument::class, [Product::class], new ContainerBuilder());
+
+        return new IndexScope($index, $channelCode, 'en_US', $currencyCode);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_support_a_scope_without_a_currency(): void
+    {
+        $dataMapper = $this->createDataMapper();
+
+        self::assertFalse($dataMapper->supports(
+            new Product(),
+            new ProductDocument(),
+            $this->createIndexScope('FASHION_WEB', null),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_support_a_scope_without_a_channel(): void
+    {
+        $dataMapper = $this->createDataMapper();
+
+        self::assertFalse($dataMapper->supports(
+            new Product(),
+            new ProductDocument(),
+            $this->createIndexScope(null, 'USD'),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_supports_a_scope_with_both_a_channel_and_a_currency(): void
+    {
+        $dataMapper = $this->createDataMapper();
+
+        self::assertTrue($dataMapper->supports(
+            new Product(),
+            new ProductDocument(),
+            $this->createIndexScope('FASHION_WEB', 'USD'),
+        ));
+    }
+}

--- a/tests/Unit/Normalizer/SettingsNormalizerTest.php
+++ b/tests/Unit/Normalizer/SettingsNormalizerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Normalizer\SettingsNormalizer;
+use Setono\SyliusMeilisearchPlugin\Settings\Settings;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Normalizer\SettingsNormalizer
+ */
+final class SettingsNormalizerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_keeps_empty_arrays_so_list_settings_can_be_reset(): void
+    {
+        $settings = new Settings();
+
+        $inner = $this->prophesize(NormalizerInterface::class);
+        $inner->normalize($settings, null, [])->willReturn([
+            'searchableAttributes' => ['*'],
+            'filterableAttributes' => [],
+            'sortableAttributes' => [],
+            'stopWords' => [],
+            'synonyms' => [],
+            'distinctAttribute' => null,
+        ]);
+
+        $normalizer = new SettingsNormalizer($inner->reveal());
+
+        $result = $normalizer->normalize($settings);
+
+        // empty arrays are preserved (sending [] resets a partial-update setting)
+        self::assertArrayHasKey('filterableAttributes', $result);
+        self::assertSame([], $result['filterableAttributes']);
+        self::assertSame([], $result['sortableAttributes']);
+        self::assertSame([], $result['stopWords']);
+        self::assertSame([], $result['synonyms']);
+
+        // null values are still stripped
+        self::assertArrayNotHasKey('distinctAttribute', $result);
+    }
+}


### PR DESCRIPTION
## What

`SettingsNormalizer` stripped empty arrays from the normalized settings before sending them to Meilisearch. Since `updateSettings` is a **partial** update, this meant a setting could never be cleared: if a project removes its last `#[Facetable]`/`#[Sortable]` attribute (or empties stop words, etc.), the previously-applied values stayed live in Meilisearch forever — reindexing did not reset them.

Now only `null` values are stripped. Empty arrays are meaningful for list-valued settings (`filterableAttributes`, `sortableAttributes`, `stopWords`, `synonyms`, …) — sending `[]` is exactly how you reset them. Keys that must be omitted when "not configured" are already modelled as `null` in `Settings` (e.g. `distinctAttribute`, `searchCutoffMs`), and `displayed`/`searchableAttributes` fall back to `['*']` via `UniqueList::ifEmpty`, so they never emit `[]`.

## Testing

Added `SettingsNormalizerTest` asserting that an explicitly-empty `filterableAttributes` normalizes to a payload containing `"filterableAttributes": []`, while `null` values are still dropped.

Closes #117

---
_Stacked on #147 (#114)._