### PR TITLE
Escape facet values in Meilisearch filter expressions

### DIFF
--- a/src/Meilisearch/Filter/ArrayFilterBuilder.php
+++ b/src/Meilisearch/Filter/ArrayFilterBuilder.php
@@ -20,7 +20,10 @@ final class ArrayFilterBuilder implements FilterBuilderInterface
                         continue;
                     }
 
-                    $query[] = sprintf('%s = "%s"', $facet->name, $value);
+                    // Escape backslashes and double quotes per Meilisearch's filter-expression
+                    // rules so a value coming straight from the request cannot break out of the
+                    // quoted string or inject filter syntax.
+                    $query[] = sprintf('%s = "%s"', $facet->name, addcslashes($value, '\\"'));
                 }
             }
 

--- a/src/Normalizer/SettingsNormalizer.php
+++ b/src/Normalizer/SettingsNormalizer.php
@@ -29,13 +29,12 @@ final class SettingsNormalizer implements NormalizerInterface
             throw new LogicException('The normalized settings data must be an array or an ArrayObject');
         }
 
-        return array_filter($data, static function (mixed $value): bool {
-            if (is_array($value)) {
-                return [] !== $value;
-            }
-
-            return null !== $value;
-        });
+        // Only strip null values. Empty arrays are meaningful for list-valued settings
+        // (filterableAttributes, sortableAttributes, stopWords, synonyms, …): because
+        // updateSettings is a *partial* update, sending [] is exactly how you reset such a
+        // setting. Keys that must be omitted when "not configured" are modelled as null in
+        // Settings, not as [].
+        return array_filter($data, static fn (mixed $value): bool => null !== $value);
     }
 
     /**

--- a/tests/Unit/Meilisearch/Builder/ArrayFilterBuilderTest.php
+++ b/tests/Unit/Meilisearch/Builder/ArrayFilterBuilderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Meilisearch\Builder;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Facet;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\ArrayFilterBuilder;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\ArrayFilterBuilder
+ */
+final class ArrayFilterBuilderTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_builds_a_filter_expression_for_array_facets(): void
+    {
+        $builder = new ArrayFilterBuilder();
+
+        $filters = $builder->build(
+            ['brand' => new Facet('brand', 'array')],
+            ['brand' => ['brand1', 'brand2']],
+        );
+
+        self::assertSame(['(brand = "brand1" OR brand = "brand2")'], $filters);
+    }
+
+    /**
+     * @test
+     */
+    public function it_escapes_double_quotes_and_backslashes_in_values(): void
+    {
+        $builder = new ArrayFilterBuilder();
+
+        $filters = $builder->build(
+            ['brand' => new Facet('brand', 'array')],
+            ['brand' => ['fo"o', 'ba\\r']],
+        );
+
+        // A double quote and a backslash must be escaped so the value cannot break out of the
+        // quoted string or inject filter syntax. Meilisearch un-escapes these back to fo"o / ba\r.
+        self::assertSame(['(brand = "fo\\"o" OR brand = "ba\\\\r")'], $filters);
+    }
+
+    /**
+     * @test
+     */
+    public function it_skips_empty_and_non_string_values(): void
+    {
+        $builder = new ArrayFilterBuilder();
+
+        $filters = $builder->build(
+            ['brand' => new Facet('brand', 'array')],
+            ['brand' => ['', 'valid', 123, null]],
+        );
+
+        self::assertSame(['(brand = "valid")'], $filters);
+    }
+}

--- a/tests/Unit/Normalizer/SettingsNormalizerTest.php
+++ b/tests/Unit/Normalizer/SettingsNormalizerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Normalizer\SettingsNormalizer;
+use Setono\SyliusMeilisearchPlugin\Settings\Settings;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Normalizer\SettingsNormalizer
+ */
+final class SettingsNormalizerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_keeps_empty_arrays_so_list_settings_can_be_reset(): void
+    {
+        $settings = new Settings();
+
+        $inner = $this->prophesize(NormalizerInterface::class);
+        $inner->normalize($settings, null, [])->willReturn([
+            'searchableAttributes' => ['*'],
+            'filterableAttributes' => [],
+            'sortableAttributes' => [],
+            'stopWords' => [],
+            'synonyms' => [],
+            'distinctAttribute' => null,
+        ]);
+
+        $normalizer = new SettingsNormalizer($inner->reveal());
+
+        $result = $normalizer->normalize($settings);
+
+        // empty arrays are preserved (sending [] resets a partial-update setting)
+        self::assertArrayHasKey('filterableAttributes', $result);
+        self::assertSame([], $result['filterableAttributes']);
+        self::assertSame([], $result['sortableAttributes']);
+        self::assertSame([], $result['stopWords']);
+        self::assertSame([], $result['synonyms']);
+
+        // null values are still stripped
+        self::assertArrayNotHasKey('distinctAttribute', $result);
+    }
+}


### PR DESCRIPTION
## What

`ArrayFilterBuilder` interpolated facet values **straight from the request** (`f` query parameter) into Meilisearch filter expressions without escaping. A value containing a double quote broke the filter expression — Meilisearch rejected the query and the search page errored — and it allowed injecting arbitrary filter syntax into the expression.

`?f[brand][]=fo"o` produced `brand = "fo"o"` → invalid filter → the whole search request failed.

Now backslashes and double quotes are escaped with `addcslashes($value, '\\"')` per Meilisearch's filter-expression escaping rules. The numeric (`FloatFilterBuilder`) and boolean (`BooleanFilterBuilder`) builders are type-guarded and don't interpolate raw strings, so only this path was affected.

## Testing

Added `ArrayFilterBuilderTest` covering normal building, escaping of `"` and `\`, and skipping empty/non-string values.

Closes #115

---
_Stacked on #148 (#117)._