### PR TITLE
Validate the sort query parameter before it reaches Meilisearch

### DIFF
--- a/src/Document/Metadata/Metadata.php
+++ b/src/Document/Metadata/Metadata.php
@@ -106,4 +106,24 @@ final class Metadata
     {
         return array_keys($this->sortableAttributes);
     }
+
+    /**
+     * Returns every valid sort value (`<attribute>:<asc|desc>`) for the sortable attributes,
+     * respecting any direction restriction declared via #[Sortable(direction:)]. This is the
+     * whitelist a user-supplied sort parameter must match before it is passed to Meilisearch.
+     *
+     * @return list<string>
+     */
+    public function getSortableValues(): array
+    {
+        $values = [];
+
+        foreach ($this->sortableAttributes as $sortable) {
+            foreach ($sortable->directions() as $direction) {
+                $values[] = sprintf('%s:%s', $sortable->name, $direction);
+            }
+        }
+
+        return $values;
+    }
 }

--- a/src/Document/Metadata/Sortable.php
+++ b/src/Document/Metadata/Sortable.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Setono\SyliusMeilisearchPlugin\Document\Metadata;
 
+use Setono\SyliusMeilisearchPlugin\Document\Attribute\Sortable as SortableAttribute;
+
 final class Sortable
 {
     public function __construct(
@@ -13,5 +15,20 @@ final class Sortable
          */
         public readonly ?string $direction = null,
     ) {
+    }
+
+    /**
+     * The directions this attribute may be sorted in, respecting any restriction
+     * declared via #[Sortable(direction:)].
+     *
+     * @return list<string>
+     */
+    public function directions(): array
+    {
+        if (null === $this->direction) {
+            return [SortableAttribute::ASC, SortableAttribute::DESC];
+        }
+
+        return [$this->direction];
     }
 }

--- a/src/Form/Builder/SortingFormBuilder.php
+++ b/src/Form/Builder/SortingFormBuilder.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Setono\SyliusMeilisearchPlugin\Form\Builder;
 
-use Setono\SyliusMeilisearchPlugin\Document\Attribute\Sortable as SortableAttribute;
 use Setono\SyliusMeilisearchPlugin\Document\Metadata\Metadata;
-use Setono\SyliusMeilisearchPlugin\Document\Metadata\Sortable;
 use Setono\SyliusMeilisearchPlugin\Engine\SearchRequest;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -17,7 +15,7 @@ final class SortingFormBuilder implements SortingFormBuilderInterface
     {
         $choices = [];
         foreach ($metadata->sortableAttributes as $sortable) {
-            foreach (self::resolveDirections($sortable) as $direction) {
+            foreach ($sortable->directions() as $direction) {
                 $choices[sprintf('setono_sylius_meilisearch.form.search.sorting.%s.%s', $sortable->name, $direction)] = sprintf('%s:%s', $sortable->name, $direction);
             }
         }
@@ -26,17 +24,5 @@ final class SortingFormBuilder implements SortingFormBuilderInterface
             'required' => false,
             'placeholder' => 'setono_sylius_meilisearch.form.search.sorting.placeholder',
         ]);
-    }
-
-    /**
-     * @return list<string>
-     */
-    private static function resolveDirections(Sortable $sortable): array
-    {
-        if (null === $sortable->direction) {
-            return [SortableAttribute::ASC, SortableAttribute::DESC];
-        }
-
-        return [$sortable->direction];
     }
 }

--- a/src/Meilisearch/Filter/ArrayFilterBuilder.php
+++ b/src/Meilisearch/Filter/ArrayFilterBuilder.php
@@ -20,7 +20,10 @@ final class ArrayFilterBuilder implements FilterBuilderInterface
                         continue;
                     }
 
-                    $query[] = sprintf('%s = "%s"', $facet->name, $value);
+                    // Escape backslashes and double quotes per Meilisearch's filter-expression
+                    // rules so a value coming straight from the request cannot break out of the
+                    // quoted string or inject filter syntax.
+                    $query[] = sprintf('%s = "%s"', $facet->name, addcslashes($value, '\\"'));
                 }
             }
 

--- a/src/Meilisearch/Query/MultiSearchBuilder.php
+++ b/src/Meilisearch/Query/MultiSearchBuilder.php
@@ -28,8 +28,16 @@ final class MultiSearchBuilder implements MultiSearchBuilderInterface
 
         $filters = $this->filterBuilder->build($facets, $searchRequest->filters);
 
+        // The sort parameter comes straight from the request. Validate it against the document's
+        // sortable attributes before it reaches Meilisearch: an unknown attribute or an invalid
+        // direction would otherwise make Meilisearch reject the whole query and error the page.
+        // Anything that doesn't match silently falls back to relevance (no sort).
+        $sort = null !== $searchRequest->sort && in_array($searchRequest->sort, $metadata->getSortableValues(), true)
+            ? $searchRequest->sort
+            : null;
+
         return array_merge(
-            [$this->buildSearchQuery($index, $searchRequest, $facetsNames, $filters)],
+            [$this->buildSearchQuery($index, $searchRequest, $facetsNames, $filters, $sort)],
             $this->buildFacetQueries($index, $searchRequest, $facets, $searchRequest->filters),
         );
     }
@@ -38,7 +46,7 @@ final class MultiSearchBuilder implements MultiSearchBuilderInterface
      * @param list<string> $facetNames
      * @param list<string> $filters
      */
-    private function buildSearchQuery(Index $index, SearchRequest $searchRequest, array $facetNames, array $filters): SearchQuery
+    private function buildSearchQuery(Index $index, SearchRequest $searchRequest, array $facetNames, array $filters, ?string $sort): SearchQuery
     {
         $query = $this->searchQueryBuilder
             ->build($index->uid(), $searchRequest->query, $facetNames, $filters)
@@ -46,8 +54,8 @@ final class MultiSearchBuilder implements MultiSearchBuilderInterface
             ->setPage($searchRequest->page)
         ;
 
-        if (null !== $searchRequest->sort) {
-            $query->setSort([$searchRequest->sort]);
+        if (null !== $sort) {
+            $query->setSort([$sort]);
         }
 
         return $query;

--- a/tests/Unit/Document/Metadata/MetadataTest.php
+++ b/tests/Unit/Document/Metadata/MetadataTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Document\Metadata;
 
 use PHPUnit\Framework\TestCase;
+use Setono\SyliusMeilisearchPlugin\Document\Attribute\Sortable as SortableAttribute;
 use Setono\SyliusMeilisearchPlugin\Document\Metadata\Metadata;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Sortable;
 
 final class MetadataTest extends TestCase
 {
@@ -17,5 +19,21 @@ final class MetadataTest extends TestCase
         $doc = new Document();
         $metadata = new Metadata($doc);
         self::assertSame($doc::class, $metadata->document);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_valid_sortable_values_respecting_direction_restrictions(): void
+    {
+        $metadata = new Metadata(Document::class);
+        $metadata->sortableAttributes['createdAt'] = new Sortable('createdAt');
+        $metadata->sortableAttributes['price'] = new Sortable('price', SortableAttribute::ASC);
+
+        self::assertSame([
+            'createdAt:asc',
+            'createdAt:desc',
+            'price:asc',
+        ], $metadata->getSortableValues());
     }
 }

--- a/tests/Unit/Meilisearch/Builder/ArrayFilterBuilderTest.php
+++ b/tests/Unit/Meilisearch/Builder/ArrayFilterBuilderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Meilisearch\Builder;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Facet;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\ArrayFilterBuilder;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\ArrayFilterBuilder
+ */
+final class ArrayFilterBuilderTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_builds_a_filter_expression_for_array_facets(): void
+    {
+        $builder = new ArrayFilterBuilder();
+
+        $filters = $builder->build(
+            ['brand' => new Facet('brand', 'array')],
+            ['brand' => ['brand1', 'brand2']],
+        );
+
+        self::assertSame(['(brand = "brand1" OR brand = "brand2")'], $filters);
+    }
+
+    /**
+     * @test
+     */
+    public function it_escapes_double_quotes_and_backslashes_in_values(): void
+    {
+        $builder = new ArrayFilterBuilder();
+
+        $filters = $builder->build(
+            ['brand' => new Facet('brand', 'array')],
+            ['brand' => ['fo"o', 'ba\\r']],
+        );
+
+        // A double quote and a backslash must be escaped so the value cannot break out of the
+        // quoted string or inject filter syntax. Meilisearch un-escapes these back to fo"o / ba\r.
+        self::assertSame(['(brand = "fo\\"o" OR brand = "ba\\\\r")'], $filters);
+    }
+
+    /**
+     * @test
+     */
+    public function it_skips_empty_and_non_string_values(): void
+    {
+        $builder = new ArrayFilterBuilder();
+
+        $filters = $builder->build(
+            ['brand' => new Facet('brand', 'array')],
+            ['brand' => ['', 'valid', 123, null]],
+        );
+
+        self::assertSame(['(brand = "valid")'], $filters);
+    }
+}

--- a/tests/Unit/Meilisearch/Query/MultiSearchBuilderTest.php
+++ b/tests/Unit/Meilisearch/Query/MultiSearchBuilderTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Meilisearch\Query;
+
+use Meilisearch\Contracts\SearchQuery;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Document\Attribute\Sortable as SortableAttribute;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Metadata;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactoryInterface;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Sortable;
+use Setono\SyliusMeilisearchPlugin\Document\Product as ProductDocument;
+use Setono\SyliusMeilisearchPlugin\Engine\SearchRequest;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\FilterBuilderInterface;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Query\MultiSearchBuilder;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Query\SearchQueryBuilderInterface;
+use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
+use Setono\SyliusMeilisearchPlugin\Tests\Application\Entity\Product;
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Meilisearch\Query\MultiSearchBuilder
+ */
+final class MultiSearchBuilderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private function createBuilder(): MultiSearchBuilder
+    {
+        $searchQueryBuilder = $this->prophesize(SearchQueryBuilderInterface::class);
+        $searchQueryBuilder->build(Argument::cetera())->will(static fn (): SearchQuery => new SearchQuery());
+
+        $filterBuilder = $this->prophesize(FilterBuilderInterface::class);
+        $filterBuilder->build(Argument::cetera())->willReturn([]);
+
+        return new MultiSearchBuilder($searchQueryBuilder->reveal(), $filterBuilder->reveal(), 60);
+    }
+
+    private function createIndex(): Index
+    {
+        $metadata = new Metadata(ProductDocument::class);
+        $metadata->sortableAttributes['createdAt'] = new Sortable('createdAt');
+        $metadata->sortableAttributes['price'] = new Sortable('price', SortableAttribute::ASC);
+
+        $metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $metadataFactory->getMetadataFor(ProductDocument::class)->willReturn($metadata);
+
+        $uidResolver = $this->prophesize(IndexUidResolverInterface::class);
+        $uidResolver->resolve(Argument::type(Index::class))->willReturn('products__test');
+
+        $locator = new Container();
+        $locator->set(MetadataFactoryInterface::class, $metadataFactory->reveal());
+        $locator->set(IndexUidResolverInterface::class, $uidResolver->reveal());
+
+        return new Index('products', ProductDocument::class, [Product::class], $locator);
+    }
+
+    private function buildSort(?string $sort): ?array
+    {
+        $queries = $this->createBuilder()->build(
+            $this->createIndex(),
+            new SearchRequest('query', [], 1, $sort),
+        );
+
+        return $queries[0]->toArray()['sort'] ?? null;
+    }
+
+    /**
+     * @test
+     */
+    public function it_applies_a_valid_sort(): void
+    {
+        self::assertSame(['createdAt:asc'], $this->buildSort('createdAt:asc'));
+        self::assertSame(['createdAt:desc'], $this->buildSort('createdAt:desc'));
+        self::assertSame(['price:asc'], $this->buildSort('price:asc'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_falls_back_to_relevance_for_an_unknown_attribute(): void
+    {
+        self::assertNull($this->buildSort('unknown:asc'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_falls_back_to_relevance_for_a_disallowed_direction(): void
+    {
+        // price is restricted to asc via #[Sortable(direction: 'asc')]
+        self::assertNull($this->buildSort('price:desc'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_falls_back_to_relevance_for_garbage_input(): void
+    {
+        self::assertNull($this->buildSort('garbage'));
+        self::assertNull($this->buildSort('createdAt'));
+        self::assertNull($this->buildSort('createdAt:asc:desc'));
+        self::assertNull($this->buildSort(null));
+    }
+}


### PR DESCRIPTION
## What

The `?s=` sort query parameter was passed verbatim to Meilisearch's `setSort()`. Any value that isn't a valid `<sortableAttribute>:<asc|desc>` pair made Meilisearch reject the query — and the whole search page errored with a raw exception. Anyone could 500 a store's search page by editing the URL.

The sort value is now validated against the document metadata's sortable attributes (plus an `:asc`/`:desc` suffix, respecting any `#[Sortable(direction:)]` restriction) before it reaches the query builder, and silently falls back to relevance (no sort) when it doesn't match.

Direction resolution is centralised on `Document\Metadata\Sortable::directions()`, so the sorting-form dropdown (`SortingFormBuilder`) and the validation whitelist (`Metadata::getSortableValues()`) derive from a single source of truth and can't drift.

## Testing

- `MetadataTest::it_returns_the_valid_sortable_values_respecting_direction_restrictions`
- `MultiSearchBuilderTest`: a valid sort is applied; an unknown attribute, a disallowed direction (a `#[Sortable(direction: 'asc')]` attribute asked to sort `desc`), and garbage input all result in no sort being applied.

Closes #116

---
_Stacked on #149 (#115)._