### PR TITLE
Scope IndexCommand --wait to this run's index uids

### DIFF
--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -8,6 +8,8 @@ use Meilisearch\Client;
 use Meilisearch\Contracts\TasksQuery;
 use Setono\SyliusMeilisearchPlugin\Config\IndexRegistryInterface;
 use Setono\SyliusMeilisearchPlugin\Message\Command\Index;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScopeProviderInterface;
+use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
@@ -27,6 +29,8 @@ final class IndexCommand extends Command
         private readonly MessageBusInterface $commandBus,
         private readonly IndexRegistryInterface $indexRegistry,
         private readonly Client $client,
+        private readonly IndexScopeProviderInterface $indexScopeProvider,
+        private readonly IndexUidResolverInterface $indexUidResolver,
     ) {
         parent::__construct();
     }
@@ -94,18 +98,42 @@ final class IndexCommand extends Command
         $wait = $input->getOption('wait');
 
         if ($wait) {
-            $this->wait((int) $input->getOption('wait-timeout'), $output);
+            $this->wait($this->resolveIndexUids($indexes), (int) $input->getOption('wait-timeout'), $output);
         }
 
         return 0;
     }
 
-    private function wait(int $waitTimeout, OutputInterface $output): void
+    /**
+     * Resolves the concrete Meilisearch index uids (across all scopes) for the given index names,
+     * so --wait only waits on tasks belonging to this run rather than every task on the instance.
+     *
+     * @param list<string> $indexes
+     *
+     * @return list<string>
+     */
+    private function resolveIndexUids(array $indexes): array
+    {
+        $uids = [];
+
+        foreach ($indexes as $index) {
+            foreach ($this->indexScopeProvider->getAll($this->indexRegistry->get($index)) as $indexScope) {
+                $uid = $this->indexUidResolver->resolveFromIndexScope($indexScope);
+                $uids[$uid] = $uid;
+            }
+        }
+
+        return array_values($uids);
+    }
+
+    /**
+     * @param list<string> $indexUids
+     */
+    private function wait(array $indexUids, int $waitTimeout, OutputInterface $output): void
     {
         $start = time();
 
-        $query = new TasksQuery();
-        $query->setStatuses(['enqueued', 'processing']);
+        $query = self::createTasksQuery($indexUids);
 
         do {
             $results = $this->client->getTasks($query);
@@ -120,5 +148,23 @@ final class IndexCommand extends Command
         } while ((time() - $start) < $waitTimeout);
 
         throw new RuntimeException(sprintf('The indexing did not finish within the specified time (%d seconds)', $waitTimeout));
+    }
+
+    /**
+     * @param list<string> $indexUids
+     */
+    public static function createTasksQuery(array $indexUids): TasksQuery
+    {
+        $query = new TasksQuery();
+        $query->setStatuses(['enqueued', 'processing']);
+
+        // Scope the query to this run's index uids so we don't wait on unrelated tasks from
+        // other developers/environments sharing the same Meilisearch instance (the exact
+        // scenario MEILISEARCH_PREFIX exists for).
+        if ([] !== $indexUids) {
+            $query->setIndexUids($indexUids);
+        }
+
+        return $query;
     }
 }

--- a/src/Document/Metadata/Metadata.php
+++ b/src/Document/Metadata/Metadata.php
@@ -106,4 +106,24 @@ final class Metadata
     {
         return array_keys($this->sortableAttributes);
     }
+
+    /**
+     * Returns every valid sort value (`<attribute>:<asc|desc>`) for the sortable attributes,
+     * respecting any direction restriction declared via #[Sortable(direction:)]. This is the
+     * whitelist a user-supplied sort parameter must match before it is passed to Meilisearch.
+     *
+     * @return list<string>
+     */
+    public function getSortableValues(): array
+    {
+        $values = [];
+
+        foreach ($this->sortableAttributes as $sortable) {
+            foreach ($sortable->directions() as $direction) {
+                $values[] = sprintf('%s:%s', $sortable->name, $direction);
+            }
+        }
+
+        return $values;
+    }
 }

--- a/src/Document/Metadata/Sortable.php
+++ b/src/Document/Metadata/Sortable.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Setono\SyliusMeilisearchPlugin\Document\Metadata;
 
+use Setono\SyliusMeilisearchPlugin\Document\Attribute\Sortable as SortableAttribute;
+
 final class Sortable
 {
     public function __construct(
@@ -13,5 +15,20 @@ final class Sortable
          */
         public readonly ?string $direction = null,
     ) {
+    }
+
+    /**
+     * The directions this attribute may be sorted in, respecting any restriction
+     * declared via #[Sortable(direction:)].
+     *
+     * @return list<string>
+     */
+    public function directions(): array
+    {
+        if (null === $this->direction) {
+            return [SortableAttribute::ASC, SortableAttribute::DESC];
+        }
+
+        return [$this->direction];
     }
 }

--- a/src/Form/Builder/SortingFormBuilder.php
+++ b/src/Form/Builder/SortingFormBuilder.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Setono\SyliusMeilisearchPlugin\Form\Builder;
 
-use Setono\SyliusMeilisearchPlugin\Document\Attribute\Sortable as SortableAttribute;
 use Setono\SyliusMeilisearchPlugin\Document\Metadata\Metadata;
-use Setono\SyliusMeilisearchPlugin\Document\Metadata\Sortable;
 use Setono\SyliusMeilisearchPlugin\Engine\SearchRequest;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -17,7 +15,7 @@ final class SortingFormBuilder implements SortingFormBuilderInterface
     {
         $choices = [];
         foreach ($metadata->sortableAttributes as $sortable) {
-            foreach (self::resolveDirections($sortable) as $direction) {
+            foreach ($sortable->directions() as $direction) {
                 $choices[sprintf('setono_sylius_meilisearch.form.search.sorting.%s.%s', $sortable->name, $direction)] = sprintf('%s:%s', $sortable->name, $direction);
             }
         }
@@ -26,17 +24,5 @@ final class SortingFormBuilder implements SortingFormBuilderInterface
             'required' => false,
             'placeholder' => 'setono_sylius_meilisearch.form.search.sorting.placeholder',
         ]);
-    }
-
-    /**
-     * @return list<string>
-     */
-    private static function resolveDirections(Sortable $sortable): array
-    {
-        if (null === $sortable->direction) {
-            return [SortableAttribute::ASC, SortableAttribute::DESC];
-        }
-
-        return [$sortable->direction];
     }
 }

--- a/src/Meilisearch/Query/MultiSearchBuilder.php
+++ b/src/Meilisearch/Query/MultiSearchBuilder.php
@@ -28,8 +28,16 @@ final class MultiSearchBuilder implements MultiSearchBuilderInterface
 
         $filters = $this->filterBuilder->build($facets, $searchRequest->filters);
 
+        // The sort parameter comes straight from the request. Validate it against the document's
+        // sortable attributes before it reaches Meilisearch: an unknown attribute or an invalid
+        // direction would otherwise make Meilisearch reject the whole query and error the page.
+        // Anything that doesn't match silently falls back to relevance (no sort).
+        $sort = null !== $searchRequest->sort && in_array($searchRequest->sort, $metadata->getSortableValues(), true)
+            ? $searchRequest->sort
+            : null;
+
         return array_merge(
-            [$this->buildSearchQuery($index, $searchRequest, $facetsNames, $filters)],
+            [$this->buildSearchQuery($index, $searchRequest, $facetsNames, $filters, $sort)],
             $this->buildFacetQueries($index, $searchRequest, $facets, $searchRequest->filters),
         );
     }
@@ -38,7 +46,7 @@ final class MultiSearchBuilder implements MultiSearchBuilderInterface
      * @param list<string> $facetNames
      * @param list<string> $filters
      */
-    private function buildSearchQuery(Index $index, SearchRequest $searchRequest, array $facetNames, array $filters): SearchQuery
+    private function buildSearchQuery(Index $index, SearchRequest $searchRequest, array $facetNames, array $filters, ?string $sort): SearchQuery
     {
         $query = $this->searchQueryBuilder
             ->build($index->uid(), $searchRequest->query, $facetNames, $filters)
@@ -46,8 +54,8 @@ final class MultiSearchBuilder implements MultiSearchBuilderInterface
             ->setPage($searchRequest->page)
         ;
 
-        if (null !== $searchRequest->sort) {
-            $query->setSort([$searchRequest->sort]);
+        if (null !== $sort) {
+            $query->setSort([$sort]);
         }
 
         return $query;

--- a/src/Resources/config/services/command.xml
+++ b/src/Resources/config/services/command.xml
@@ -6,6 +6,8 @@
             <argument type="service" id="setono_sylius_meilisearch.command_bus"/>
             <argument type="service" id="setono_sylius_meilisearch.config.index_registry"/>
             <argument type="service" id="Meilisearch\Client"/>
+            <argument type="service" id="Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScopeProviderInterface"/>
+            <argument type="service" id="Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface"/>
 
             <tag name="console.command"/>
         </service>

--- a/tests/Unit/Command/IndexCommandTest.php
+++ b/tests/Unit/Command/IndexCommandTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Command;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusMeilisearchPlugin\Command\IndexCommand;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Command\IndexCommand
+ */
+final class IndexCommandTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_scopes_the_tasks_query_to_the_given_index_uids(): void
+    {
+        $query = IndexCommand::createTasksQuery(['products__test', 'taxons__test']);
+
+        $array = $query->toArray();
+
+        self::assertSame('enqueued,processing', $array['statuses']);
+        self::assertSame('products__test,taxons__test', $array['indexUids']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_scope_by_index_uid_when_no_uids_are_given(): void
+    {
+        $query = IndexCommand::createTasksQuery([]);
+
+        $array = $query->toArray();
+
+        self::assertSame('enqueued,processing', $array['statuses']);
+        self::assertArrayNotHasKey('indexUids', $array);
+    }
+}

--- a/tests/Unit/Document/Metadata/MetadataTest.php
+++ b/tests/Unit/Document/Metadata/MetadataTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Document\Metadata;
 
 use PHPUnit\Framework\TestCase;
+use Setono\SyliusMeilisearchPlugin\Document\Attribute\Sortable as SortableAttribute;
 use Setono\SyliusMeilisearchPlugin\Document\Metadata\Metadata;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Sortable;
 
 final class MetadataTest extends TestCase
 {
@@ -17,5 +19,21 @@ final class MetadataTest extends TestCase
         $doc = new Document();
         $metadata = new Metadata($doc);
         self::assertSame($doc::class, $metadata->document);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_valid_sortable_values_respecting_direction_restrictions(): void
+    {
+        $metadata = new Metadata(Document::class);
+        $metadata->sortableAttributes['createdAt'] = new Sortable('createdAt');
+        $metadata->sortableAttributes['price'] = new Sortable('price', SortableAttribute::ASC);
+
+        self::assertSame([
+            'createdAt:asc',
+            'createdAt:desc',
+            'price:asc',
+        ], $metadata->getSortableValues());
     }
 }

--- a/tests/Unit/Meilisearch/Query/MultiSearchBuilderTest.php
+++ b/tests/Unit/Meilisearch/Query/MultiSearchBuilderTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Meilisearch\Query;
+
+use Meilisearch\Contracts\SearchQuery;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Document\Attribute\Sortable as SortableAttribute;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Metadata;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactoryInterface;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Sortable;
+use Setono\SyliusMeilisearchPlugin\Document\Product as ProductDocument;
+use Setono\SyliusMeilisearchPlugin\Engine\SearchRequest;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\FilterBuilderInterface;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Query\MultiSearchBuilder;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Query\SearchQueryBuilderInterface;
+use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
+use Setono\SyliusMeilisearchPlugin\Tests\Application\Entity\Product;
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Meilisearch\Query\MultiSearchBuilder
+ */
+final class MultiSearchBuilderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private function createBuilder(): MultiSearchBuilder
+    {
+        $searchQueryBuilder = $this->prophesize(SearchQueryBuilderInterface::class);
+        $searchQueryBuilder->build(Argument::cetera())->will(static fn (): SearchQuery => new SearchQuery());
+
+        $filterBuilder = $this->prophesize(FilterBuilderInterface::class);
+        $filterBuilder->build(Argument::cetera())->willReturn([]);
+
+        return new MultiSearchBuilder($searchQueryBuilder->reveal(), $filterBuilder->reveal(), 60);
+    }
+
+    private function createIndex(): Index
+    {
+        $metadata = new Metadata(ProductDocument::class);
+        $metadata->sortableAttributes['createdAt'] = new Sortable('createdAt');
+        $metadata->sortableAttributes['price'] = new Sortable('price', SortableAttribute::ASC);
+
+        $metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $metadataFactory->getMetadataFor(ProductDocument::class)->willReturn($metadata);
+
+        $uidResolver = $this->prophesize(IndexUidResolverInterface::class);
+        $uidResolver->resolve(Argument::type(Index::class))->willReturn('products__test');
+
+        $locator = new Container();
+        $locator->set(MetadataFactoryInterface::class, $metadataFactory->reveal());
+        $locator->set(IndexUidResolverInterface::class, $uidResolver->reveal());
+
+        return new Index('products', ProductDocument::class, [Product::class], $locator);
+    }
+
+    private function buildSort(?string $sort): ?array
+    {
+        $queries = $this->createBuilder()->build(
+            $this->createIndex(),
+            new SearchRequest('query', [], 1, $sort),
+        );
+
+        return $queries[0]->toArray()['sort'] ?? null;
+    }
+
+    /**
+     * @test
+     */
+    public function it_applies_a_valid_sort(): void
+    {
+        self::assertSame(['createdAt:asc'], $this->buildSort('createdAt:asc'));
+        self::assertSame(['createdAt:desc'], $this->buildSort('createdAt:desc'));
+        self::assertSame(['price:asc'], $this->buildSort('price:asc'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_falls_back_to_relevance_for_an_unknown_attribute(): void
+    {
+        self::assertNull($this->buildSort('unknown:asc'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_falls_back_to_relevance_for_a_disallowed_direction(): void
+    {
+        // price is restricted to asc via #[Sortable(direction: 'asc')]
+        self::assertNull($this->buildSort('price:desc'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_falls_back_to_relevance_for_garbage_input(): void
+    {
+        self::assertNull($this->buildSort('garbage'));
+        self::assertNull($this->buildSort('createdAt'));
+        self::assertNull($this->buildSort('createdAt:asc:desc'));
+        self::assertNull($this->buildSort(null));
+    }
+}


### PR DESCRIPTION
## What

`setono:sylius-meilisearch:index --wait` polled **all** enqueued/processing tasks on the Meilisearch instance, not just the ones belonging to the indexes this run touched. On a shared instance — exactly the scenario `MEILISEARCH_PREFIX` exists for (multiple developers/environments on one Meilisearch) — the command blocked on unrelated tasks and could even throw its timeout `RuntimeException` because of someone else's workload.

The command now resolves the concrete index uids (across all scopes) for the indexes being processed — via the same `IndexScopeProvider` + `IndexUidResolver` pair `IndexHandler` uses — and scopes the `TasksQuery` with `setIndexUids([...])`.

## Testing

Added `IndexCommandTest` on the built `TasksQuery` (statuses + index uids, and no `indexUids` filter when the uid list is empty). `lint:container` confirms the two new constructor dependencies wire correctly.

Closes #121

---
_Stacked on #150 (#116)._