### PR TITLE
Pin SynonymRepository substring safety with a functional test

### DIFF
--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -8,6 +8,8 @@ use Meilisearch\Client;
 use Meilisearch\Contracts\TasksQuery;
 use Setono\SyliusMeilisearchPlugin\Config\IndexRegistryInterface;
 use Setono\SyliusMeilisearchPlugin\Message\Command\Index;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScopeProviderInterface;
+use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
@@ -27,6 +29,8 @@ final class IndexCommand extends Command
         private readonly MessageBusInterface $commandBus,
         private readonly IndexRegistryInterface $indexRegistry,
         private readonly Client $client,
+        private readonly IndexScopeProviderInterface $indexScopeProvider,
+        private readonly IndexUidResolverInterface $indexUidResolver,
     ) {
         parent::__construct();
     }
@@ -94,18 +98,42 @@ final class IndexCommand extends Command
         $wait = $input->getOption('wait');
 
         if ($wait) {
-            $this->wait((int) $input->getOption('wait-timeout'), $output);
+            $this->wait($this->resolveIndexUids($indexes), (int) $input->getOption('wait-timeout'), $output);
         }
 
         return 0;
     }
 
-    private function wait(int $waitTimeout, OutputInterface $output): void
+    /**
+     * Resolves the concrete Meilisearch index uids (across all scopes) for the given index names,
+     * so --wait only waits on tasks belonging to this run rather than every task on the instance.
+     *
+     * @param list<string> $indexes
+     *
+     * @return list<string>
+     */
+    private function resolveIndexUids(array $indexes): array
+    {
+        $uids = [];
+
+        foreach ($indexes as $index) {
+            foreach ($this->indexScopeProvider->getAll($this->indexRegistry->get($index)) as $indexScope) {
+                $uid = $this->indexUidResolver->resolveFromIndexScope($indexScope);
+                $uids[$uid] = $uid;
+            }
+        }
+
+        return array_values($uids);
+    }
+
+    /**
+     * @param list<string> $indexUids
+     */
+    private function wait(array $indexUids, int $waitTimeout, OutputInterface $output): void
     {
         $start = time();
 
-        $query = new TasksQuery();
-        $query->setStatuses(['enqueued', 'processing']);
+        $query = self::createTasksQuery($indexUids);
 
         do {
             $results = $this->client->getTasks($query);
@@ -120,5 +148,23 @@ final class IndexCommand extends Command
         } while ((time() - $start) < $waitTimeout);
 
         throw new RuntimeException(sprintf('The indexing did not finish within the specified time (%d seconds)', $waitTimeout));
+    }
+
+    /**
+     * @param list<string> $indexUids
+     */
+    public static function createTasksQuery(array $indexUids): TasksQuery
+    {
+        $query = new TasksQuery();
+        $query->setStatuses(['enqueued', 'processing']);
+
+        // Scope the query to this run's index uids so we don't wait on unrelated tasks from
+        // other developers/environments sharing the same Meilisearch instance (the exact
+        // scenario MEILISEARCH_PREFIX exists for).
+        if ([] !== $indexUids) {
+            $query->setIndexUids($indexUids);
+        }
+
+        return $query;
     }
 }

--- a/src/Repository/SynonymRepository.php
+++ b/src/Repository/SynonymRepository.php
@@ -13,6 +13,10 @@ class SynonymRepository extends EntityRepository implements SynonymRepositoryInt
 {
     public function findEnabledByIndexScope(IndexScope $indexScope): array
     {
+        // The `indexes` column is a JSON list (e.g. ["products"]). The LIKE pattern is anchored
+        // to the quoted form (`%"products"%`) on purpose: without the surrounding quotes an index
+        // name that is a prefix of another (`products` vs `products_v2`) would false-positive.
+        // See SynonymRepositoryTest.
         $qb = $this->createQueryBuilder('o')
             ->andWhere('o.enabled = true')
             ->andWhere('o.indexes LIKE :index')

--- a/src/Resources/config/services/command.xml
+++ b/src/Resources/config/services/command.xml
@@ -6,6 +6,8 @@
             <argument type="service" id="setono_sylius_meilisearch.command_bus"/>
             <argument type="service" id="setono_sylius_meilisearch.config.index_registry"/>
             <argument type="service" id="Meilisearch\Client"/>
+            <argument type="service" id="Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScopeProviderInterface"/>
+            <argument type="service" id="Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface"/>
 
             <tag name="console.command"/>
         </service>

--- a/tests/Functional/Repository/SynonymRepositoryTest.php
+++ b/tests/Functional/Repository/SynonymRepositoryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Functional\Repository;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Setono\SyliusMeilisearchPlugin\Config\IndexRegistryInterface;
+use Setono\SyliusMeilisearchPlugin\Model\Synonym;
+use Setono\SyliusMeilisearchPlugin\Model\SynonymInterface;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Setono\SyliusMeilisearchPlugin\Repository\SynonymRepositoryInterface;
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Repository\SynonymRepository
+ */
+final class SynonymRepositoryTest extends KernelTestCase
+{
+    /**
+     * The `indexes` column is a JSON list and the lookup uses a quote-anchored LIKE
+     * (`%"products"%`). A synonym registered for `products_v2` must therefore not be
+     * returned when looking up synonyms for `products`, even though "products" is a
+     * substring of "products_v2".
+     *
+     * @test
+     */
+    public function it_does_not_match_an_index_name_that_is_a_prefix_of_another(): void
+    {
+        self::bootKernel(['environment' => 'test', 'debug' => true]);
+        $container = self::getContainer();
+
+        /** @var ManagerRegistry $registry */
+        $registry = $container->get('doctrine');
+
+        /** @var ObjectManager $manager */
+        $manager = $registry->getManagerForClass(Synonym::class);
+
+        /** @var RepositoryInterface<LocaleInterface> $localeRepository */
+        $localeRepository = $container->get('sylius.repository.locale');
+        $locale = $localeRepository->findOneBy([]);
+        self::assertInstanceOf(LocaleInterface::class, $locale);
+
+        $productsSynonym = $this->createSynonym('substring-safety-products', ['products'], $locale);
+        $productsV2Synonym = $this->createSynonym('substring-safety-products-v2', ['products_v2'], $locale);
+
+        $manager->persist($productsSynonym);
+        $manager->persist($productsV2Synonym);
+        $manager->flush();
+
+        try {
+            /** @var SynonymRepositoryInterface $repository */
+            $repository = $container->get('setono_sylius_meilisearch.repository.synonym');
+
+            /** @var IndexRegistryInterface $indexRegistry */
+            $indexRegistry = $container->get('setono_sylius_meilisearch.config.index_registry');
+
+            $indexScope = new IndexScope($indexRegistry->get('products'));
+
+            $terms = array_map(
+                static fn (SynonymInterface $synonym): ?string => $synonym->getTerm(),
+                array_values($repository->findEnabledByIndexScope($indexScope)),
+            );
+
+            self::assertContains('substring-safety-products', $terms);
+            self::assertNotContains('substring-safety-products-v2', $terms);
+        } finally {
+            $manager->remove($productsSynonym);
+            $manager->remove($productsV2Synonym);
+            $manager->flush();
+        }
+    }
+
+    /**
+     * @param list<string> $indexes
+     */
+    private function createSynonym(string $term, array $indexes, LocaleInterface $locale): Synonym
+    {
+        $synonym = new Synonym();
+        $synonym->setTerm($term);
+        $synonym->setSynonym($term . '-syn');
+        $synonym->setLocale($locale);
+        foreach ($indexes as $index) {
+            $synonym->addIndex($index);
+        }
+        $synonym->enable();
+
+        return $synonym;
+    }
+}

--- a/tests/Unit/Command/IndexCommandTest.php
+++ b/tests/Unit/Command/IndexCommandTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Command;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusMeilisearchPlugin\Command\IndexCommand;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Command\IndexCommand
+ */
+final class IndexCommandTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_scopes_the_tasks_query_to_the_given_index_uids(): void
+    {
+        $query = IndexCommand::createTasksQuery(['products__test', 'taxons__test']);
+
+        $array = $query->toArray();
+
+        self::assertSame('enqueued,processing', $array['statuses']);
+        self::assertSame('products__test,taxons__test', $array['indexUids']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_scope_by_index_uid_when_no_uids_are_given(): void
+    {
+        $query = IndexCommand::createTasksQuery([]);
+
+        $array = $query->toArray();
+
+        self::assertSame('enqueued,processing', $array['statuses']);
+        self::assertArrayNotHasKey('indexUids', $array);
+    }
+}


### PR DESCRIPTION
## What

`SynonymRepository::findEnabledByIndexScope()` matches against the `indexes` column with a `LIKE` pattern. The column is already stored as `json` and the pattern is already anchored to the quoted form (`%"products"%`), so an index name that is a prefix of another (`products` vs `products_v2`) does not false-positive.

This PR pins that behaviour with a functional test (persists a `products` synonym and a `products_v2` synonym, looks up synonyms for `products`, asserts only the former is returned) and adds a comment on the repository explaining why the surrounding quotes in the pattern matter — so the anchoring isn't accidentally "simplified" away.

No behavioural change: I verified the test fails if the pattern is un-anchored (`%products%`) and passes as-is.

> Note: the issue also floats migrating the column to `json` / a join table. The column is **already** `type="json"` in the Doctrine mapping, so no migration is needed.

## Testing

`SynonymRepositoryTest::it_does_not_match_an_index_name_that_is_a_prefix_of_another` (Functional suite — needs the DB).

Closes #139

---
_Stacked on #151 (#121)._