### PR TITLE
Validate default_filters keys and move config assertions into Configuration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,6 +18,7 @@ use Sylius\Component\Resource\Model\ToggleableInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 final class Configuration implements ConfigurationInterface
 {
@@ -61,7 +62,6 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('indexer')
                                 ->info(sprintf('You can set a custom indexer here. If you do not set one, the default indexer will be used. The default indexer is %s', DefaultIndexer::class))
-                                ->cannotBeEmpty()
                                 ->defaultNull()
                             ->end()
                             ->scalarNode('prefix')
@@ -72,12 +72,19 @@ final class Configuration implements ConfigurationInterface
                             ->arrayNode('default_filters')
                                 ->info(
                                     sprintf(<<<INFO
-The plugin comes with a few filters out of the box based on the entities you configure. E.g. there is an "enabled" filter if your entity implements the %s.
-You can disable/enable them here. If you want to create your own filters, you can do so by implementing the %s or by listening to the %s event
+The plugin comes with a few filters out of the box based on the entities you configure:
+- "enabled": excludes entities that implement %s and are disabled
+- "channels_aware": excludes entities that are not enabled for the current channel
+- "stock_available": excludes products that are out of stock
+You can enable/disable them here. If you want to create your own filters, you can do so by implementing the %s or by listening to the %s event
 INFO, ToggleableInterface::class, EntityFilterInterface::class, QueryBuilderForDataProvisionCreated::class),
                                 )
-                                ->useAttributeAsKey('name')
-                                ->scalarPrototype()->end()
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->booleanNode('enabled')->defaultTrue()->end()
+                                    ->booleanNode('channels_aware')->defaultTrue()->end()
+                                    ->booleanNode('stock_available')->defaultFalse()->end()
+                                ->end()
                             ->end()
                         ->end()
                     ->end()
@@ -175,6 +182,38 @@ INFO, ToggleableInterface::class, EntityFilterInterface::class, QueryBuilderForD
                         ->end()
                     ->end()
                 ->end()
+            ->end()
+            ->validate()
+                ->ifTrue(static fn (array $v): bool => array_key_exists('search', (array) ($v['indexes'] ?? [])))
+                ->thenInvalid('You cannot use "search" as an index name in setono_sylius_meilisearch.indexes. It is reserved for the search configuration.')
+            ->end()
+            ->validate()
+                ->ifTrue(static function (array $v): bool {
+                    $search = (array) ($v['search'] ?? []);
+
+                    return true === ($search['enabled'] ?? false) && null === ($search['index'] ?? null);
+                })
+                ->thenInvalid('When search is enabled you must configure the index to search under setono_sylius_meilisearch.search.index')
+            ->end()
+            ->validate()
+                ->ifTrue(static function (array $v): bool {
+                    $search = (array) ($v['search'] ?? []);
+
+                    return true === ($search['enabled'] ?? false) &&
+                        isset($search['index']) &&
+                        is_string($search['index']) &&
+                        !array_key_exists($search['index'], (array) ($v['indexes'] ?? []));
+                })
+                ->then(static function (array $v): array {
+                    $search = (array) ($v['search'] ?? []);
+                    $index = $search['index'] ?? null;
+
+                    throw new InvalidConfigurationException(sprintf(
+                        'The index "%s" configured under setono_sylius_meilisearch.search.index is not configured in setono_sylius_meilisearch.indexes. Available indexes are: [%s]',
+                        is_scalar($index) ? (string) $index : '',
+                        implode(', ', array_keys((array) ($v['indexes'] ?? []))),
+                    ));
+                })
             ->end()
         ->end()
         ;

--- a/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
+++ b/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
@@ -95,7 +95,7 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
             ->addTag('setono_sylius_meilisearch.filter_form_builder');
 
         self::registerIndexesConfiguration($config['indexes'], $container);
-        self::registerSearchConfiguration($config['search'], array_keys($config['indexes']), $container, $loader);
+        self::registerSearchConfiguration($config['search'], $container, $loader);
         self::registerAutocompleteConfiguration($config['autocomplete'], array_keys($config['indexes']), $container, $loader);
     }
 
@@ -340,9 +340,7 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
         $indexRegistry = $container->getDefinition('setono_sylius_meilisearch.config.index_registry');
 
         foreach ($config as $indexName => $index) {
-            if ('search' === $indexName) {
-                throw new \RuntimeException('You cannot use "search" as an index name. It is reserved for the search configuration');
-            }
+            // The "search" index name is reserved; this is validated in Configuration.
 
             $indexServiceId = self::getIndexServiceId($indexName);
 
@@ -395,9 +393,8 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
      * todo the search controller should only be available when search is enabled
      *
      * @param array{ enabled: bool, path: string, index: string, hits_per_page: int, taxon: array{ path: string } } $config the search configuration
-     * @param list<string> $indexes a list of index names
      */
-    private static function registerSearchConfiguration(array $config, array $indexes, ContainerBuilder $container, LoaderInterface $loader): void
+    private static function registerSearchConfiguration(array $config, ContainerBuilder $container, LoaderInterface $loader): void
     {
         $container->setParameter('setono_sylius_meilisearch.search.enabled', $config['enabled']);
         $container->setParameter('setono_sylius_meilisearch.search.path', $config['path']); // The route that uses this parameter is defined even if search is disabled
@@ -407,13 +404,7 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
             return;
         }
 
-        if (!isset($config['index'])) {
-            throw new \RuntimeException('When search is enabled, you have to configure the index for the search');
-        }
-
-        if (!in_array($config['index'], $indexes, true)) {
-            throw new \RuntimeException(sprintf('For the search configuration you have added the index "%s". That index is not configured in setono_sylius_meilisearch.indexes. Available indexes are [%s]', $config['index'], implode(', ', $indexes)));
-        }
+        // Presence and validity of $config['index'] (when search is enabled) are validated in Configuration.
 
         $container->setAlias('setono_sylius_meilisearch.index.search', self::getIndexServiceId($config['index']));
         $container->setAlias(Index::class . ' $searchIndex', self::getIndexServiceId($config['index']));

--- a/src/Repository/SynonymRepository.php
+++ b/src/Repository/SynonymRepository.php
@@ -13,6 +13,10 @@ class SynonymRepository extends EntityRepository implements SynonymRepositoryInt
 {
     public function findEnabledByIndexScope(IndexScope $indexScope): array
     {
+        // The `indexes` column is a JSON list (e.g. ["products"]). The LIKE pattern is anchored
+        // to the quoted form (`%"products"%`) on purpose: without the surrounding quotes an index
+        // name that is a prefix of another (`products` vs `products_v2`) would false-positive.
+        // See SynonymRepositoryTest.
         $qb = $this->createQueryBuilder('o')
             ->andWhere('o.enabled = true')
             ->andWhere('o.indexes LIKE :index')

--- a/tests/Functional/Repository/SynonymRepositoryTest.php
+++ b/tests/Functional/Repository/SynonymRepositoryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Functional\Repository;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Setono\SyliusMeilisearchPlugin\Config\IndexRegistryInterface;
+use Setono\SyliusMeilisearchPlugin\Model\Synonym;
+use Setono\SyliusMeilisearchPlugin\Model\SynonymInterface;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Setono\SyliusMeilisearchPlugin\Repository\SynonymRepositoryInterface;
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Repository\SynonymRepository
+ */
+final class SynonymRepositoryTest extends KernelTestCase
+{
+    /**
+     * The `indexes` column is a JSON list and the lookup uses a quote-anchored LIKE
+     * (`%"products"%`). A synonym registered for `products_v2` must therefore not be
+     * returned when looking up synonyms for `products`, even though "products" is a
+     * substring of "products_v2".
+     *
+     * @test
+     */
+    public function it_does_not_match_an_index_name_that_is_a_prefix_of_another(): void
+    {
+        self::bootKernel(['environment' => 'test', 'debug' => true]);
+        $container = self::getContainer();
+
+        /** @var ManagerRegistry $registry */
+        $registry = $container->get('doctrine');
+
+        /** @var ObjectManager $manager */
+        $manager = $registry->getManagerForClass(Synonym::class);
+
+        /** @var RepositoryInterface<LocaleInterface> $localeRepository */
+        $localeRepository = $container->get('sylius.repository.locale');
+        $locale = $localeRepository->findOneBy([]);
+        self::assertInstanceOf(LocaleInterface::class, $locale);
+
+        $productsSynonym = $this->createSynonym('substring-safety-products', ['products'], $locale);
+        $productsV2Synonym = $this->createSynonym('substring-safety-products-v2', ['products_v2'], $locale);
+
+        $manager->persist($productsSynonym);
+        $manager->persist($productsV2Synonym);
+        $manager->flush();
+
+        try {
+            /** @var SynonymRepositoryInterface $repository */
+            $repository = $container->get('setono_sylius_meilisearch.repository.synonym');
+
+            /** @var IndexRegistryInterface $indexRegistry */
+            $indexRegistry = $container->get('setono_sylius_meilisearch.config.index_registry');
+
+            $indexScope = new IndexScope($indexRegistry->get('products'));
+
+            $terms = array_map(
+                static fn (SynonymInterface $synonym): ?string => $synonym->getTerm(),
+                array_values($repository->findEnabledByIndexScope($indexScope)),
+            );
+
+            self::assertContains('substring-safety-products', $terms);
+            self::assertNotContains('substring-safety-products-v2', $terms);
+        } finally {
+            $manager->remove($productsSynonym);
+            $manager->remove($productsV2Synonym);
+            $manager->flush();
+        }
+    }
+
+    /**
+     * @param list<string> $indexes
+     */
+    private function createSynonym(string $term, array $indexes, LocaleInterface $locale): Synonym
+    {
+        $synonym = new Synonym();
+        $synonym->setTerm($term);
+        $synonym->setSynonym($term . '-syn');
+        $synonym->setLocale($locale);
+        foreach ($indexes as $index) {
+            $synonym->addIndex($index);
+        }
+        $synonym->enable();
+
+        return $synonym;
+    }
+}

--- a/tests/Unit/DependencyInjection/SetonoSyliusMeilisearchExtensionTest.php
+++ b/tests/Unit/DependencyInjection/SetonoSyliusMeilisearchExtensionTest.php
@@ -9,6 +9,7 @@ use Setono\SyliusMeilisearchPlugin\Controller\Action\SearchAction;
 use Setono\SyliusMeilisearchPlugin\DependencyInjection\SetonoSyliusMeilisearchExtension;
 use Setono\SyliusMeilisearchPlugin\Document\Product as ProductDocument;
 use Setono\SyliusMeilisearchPlugin\Tests\Application\Entity\Product as ProductEntity;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * See examples of tests and configuration options here: https://github.com/SymfonyTest/SymfonyDependencyInjectionTest
@@ -106,6 +107,46 @@ final class SetonoSyliusMeilisearchExtensionTest extends AbstractExtensionTestCa
             'search' => [
                 'path' => 'search',
                 'index' => 'products',
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_an_unknown_default_filter_key_is_used(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        // The message lists the valid keys
+        $this->expectExceptionMessageMatches('/stock_available/');
+
+        $this->load([
+            'indexes' => [
+                'products' => [
+                    'document' => ProductDocument::class,
+                    'entities' => [ProductEntity::class],
+                    'default_filters' => [
+                        'stock_availabe' => true, // typo on purpose
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_using_the_reserved_search_index_name(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageMatches('/reserved/');
+
+        $this->load([
+            'indexes' => [
+                'search' => [
+                    'document' => ProductDocument::class,
+                    'entities' => [ProductEntity::class],
+                ],
             ],
         ]);
     }


### PR DESCRIPTION
## What

Two related config-surface improvements.

**1. `default_filters` keys are now validated.** The node was an untyped `scalarPrototype()` keyed by name; a typo like `stock_availabe: true` was silently discarded. It is now three explicit `booleanNode`s (`enabled`, `channels_aware`, `stock_available`) — custom keys aren't supported anyway, so strictness costs nothing — and a typo fails container compilation with the valid keys listed. The node's `info()` now documents all three filters.

**2. Config assertions moved from the extension into `Configuration`.** Three checks that were bare `\RuntimeException`s in the extension are now `validate()->ifTrue()->thenInvalid()` closures, so errors carry config paths and surface at config-processing time:
- the reserved index name `search`
- "when search is enabled you must configure `search.index`"
- "`search.index` must be one of the configured indexes"

Also drops the contradictory `cannotBeEmpty()->defaultNull()` pair on the `indexer` node.

`InvalidConfigurationException` extends `\RuntimeException`, so the existing tests that assert a `\RuntimeException` for the search-index cases still pass.

## Testing

- `it_throws_when_an_unknown_default_filter_key_is_used` (asserts the message lists the valid keys)
- `it_throws_when_using_the_reserved_search_index_name`
- existing `it_throws_exception_if_search_index_is_not_set` / `…is_not_configured` still pass
- test-app `lint:container` passes (the test app uses `default_filters: { stock_available: true }`)

Closes #130

---
_Stacked on #152 (#139)._