### PR TITLE
Add logging to the indexing pipeline

### DIFF
--- a/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
+++ b/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
@@ -376,7 +376,7 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
     {
         $indexerServiceId = sprintf('setono_sylius_meilisearch.indexer.%s', $indexName);
 
-        $container->setDefinition($indexerServiceId, new Definition(DefaultIndexer::class, [
+        $definition = new Definition(DefaultIndexer::class, [
             new Reference($indexServiceId),
             new Reference('doctrine'),
             new Reference(IndexScopeProviderInterface::class),
@@ -388,7 +388,13 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
             new Reference('event_dispatcher'),
             new Reference('setono_sylius_meilisearch.command_bus'),
             new Reference('validator'),
-        ]));
+            new Reference('logger'),
+        ]);
+        // Routes the logger to a dedicated "setono_sylius_meilisearch" monolog channel when
+        // MonologBundle is installed; falls back to the default logger otherwise.
+        $definition->addTag('monolog.logger', ['channel' => 'setono_sylius_meilisearch']);
+
+        $container->setDefinition($indexerServiceId, $definition);
 
         return $indexerServiceId;
     }

--- a/src/Indexer/DefaultIndexer.php
+++ b/src/Indexer/DefaultIndexer.php
@@ -7,6 +7,8 @@ namespace Setono\SyliusMeilisearchPlugin\Indexer;
 use Doctrine\Persistence\ManagerRegistry;
 use Meilisearch\Client;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Setono\Doctrine\ORMTrait;
 use Setono\SyliusMeilisearchPlugin\Config\Index;
 use Setono\SyliusMeilisearchPlugin\DataMapper\DataMapperInterface;
@@ -38,6 +40,7 @@ class DefaultIndexer extends AbstractIndexer
         protected readonly EventDispatcherInterface $eventDispatcher,
         protected readonly MessageBusInterface $commandBus,
         protected readonly ValidatorInterface $validator,
+        protected readonly LoggerInterface $logger = new NullLogger(),
     ) {
         $this->managerRegistry = $managerRegistry;
     }
@@ -69,17 +72,43 @@ class DefaultIndexer extends AbstractIndexer
         }
 
         foreach ($this->indexScopeProvider->getAll($this->index) as $indexScope) {
+            $uid = $this->indexNameResolver->resolveFromIndexScope($indexScope);
+
             $documents = [];
+            $filtered = 0;
+            $invalid = 0;
 
             foreach ($entities as $entity) {
                 $document = new $this->index->document();
                 $this->dataMapper->map($entity, $document, $indexScope);
 
                 if (!$this->objectFilter->filter($entity, $document, $indexScope)) {
+                    ++$filtered;
+                    $this->logger->debug('Entity was filtered out during indexing and will not be indexed', [
+                        'index' => $uid,
+                        'entity' => $entity::class,
+                        'id' => $entity->getDocumentIdentifier(),
+                    ]);
+
                     continue;
                 }
 
-                if ($this->validator->validate($document)->count() > 0) {
+                $violations = $this->validator->validate($document);
+                if ($violations->count() > 0) {
+                    ++$invalid;
+
+                    $messages = [];
+                    foreach ($violations as $violation) {
+                        $messages[] = sprintf('%s: %s', $violation->getPropertyPath(), (string) $violation->getMessage());
+                    }
+
+                    $this->logger->warning('Document failed validation during indexing and was skipped', [
+                        'index' => $uid,
+                        'entity' => $entity::class,
+                        'id' => $entity->getDocumentIdentifier(),
+                        'violations' => $messages,
+                    ]);
+
                     continue;
                 }
 
@@ -89,7 +118,15 @@ class DefaultIndexer extends AbstractIndexer
                 $documents[] = $data;
             }
 
-            $this->client->index($this->indexNameResolver->resolveFromIndexScope($indexScope))->addDocuments($documents, 'id');
+            $this->client->index($uid)->addDocuments($documents, 'id');
+
+            $this->logger->info('Indexed a batch of entities', [
+                'index' => $uid,
+                'mapped' => count($entities),
+                'filtered' => $filtered,
+                'invalid' => $invalid,
+                'indexed' => count($documents),
+            ]);
         }
     }
 

--- a/tests/Unit/Indexer/DefaultIndexerTest.php
+++ b/tests/Unit/Indexer/DefaultIndexerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Indexer;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Meilisearch\Client;
+use Meilisearch\Endpoints\Indexes;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\DataMapper\DataMapperInterface;
+use Setono\SyliusMeilisearchPlugin\Document\Product as ProductDocument;
+use Setono\SyliusMeilisearchPlugin\Filter\Entity\EntityFilterInterface;
+use Setono\SyliusMeilisearchPlugin\Indexer\DefaultIndexer;
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScopeProviderInterface;
+use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
+use Setono\SyliusMeilisearchPlugin\Tests\Application\Entity\Product;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Indexer\DefaultIndexer
+ */
+final class DefaultIndexerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private function createIndexer(SpyLogger $logger, bool $passesFilter, ConstraintViolationList $violations): DefaultIndexer
+    {
+        $index = new Index('products', ProductDocument::class, [Product::class], new Container());
+        $indexScope = new IndexScope($index, 'FASHION_WEB', 'en_US', 'USD');
+
+        $indexScopeProvider = $this->prophesize(IndexScopeProviderInterface::class);
+        $indexScopeProvider->getAll($index)->willReturn([$indexScope]);
+
+        $uidResolver = $this->prophesize(IndexUidResolverInterface::class);
+        $uidResolver->resolveFromIndexScope($indexScope)->willReturn('products__test');
+
+        $dataMapper = $this->prophesize(DataMapperInterface::class);
+
+        $objectFilter = $this->prophesize(EntityFilterInterface::class);
+        $objectFilter->filter(Argument::cetera())->willReturn($passesFilter);
+
+        $validator = $this->prophesize(ValidatorInterface::class);
+        $validator->validate(Argument::cetera())->willReturn($violations);
+
+        $indexes = $this->prophesize(Indexes::class);
+        $indexes->addDocuments(Argument::cetera())->willReturn([]);
+
+        $client = $this->prophesize(Client::class);
+        $client->index('products__test')->willReturn($indexes->reveal());
+
+        return new DefaultIndexer(
+            $index,
+            $this->prophesize(ManagerRegistry::class)->reveal(),
+            $indexScopeProvider->reveal(),
+            $uidResolver->reveal(),
+            $dataMapper->reveal(),
+            $this->prophesize(\Symfony\Component\Serializer\Normalizer\NormalizerInterface::class)->reveal(),
+            $client->reveal(),
+            $objectFilter->reveal(),
+            $this->prophesize(EventDispatcherInterface::class)->reveal(),
+            $this->prophesize(MessageBusInterface::class)->reveal(),
+            $validator->reveal(),
+            $logger,
+        );
+    }
+
+    private function createEntity(): IndexableInterface
+    {
+        $entity = $this->prophesize(IndexableInterface::class);
+        $entity->getDocumentIdentifier()->willReturn('42');
+
+        return $entity->reveal();
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_a_warning_naming_the_entity_and_violations_when_a_document_is_invalid(): void
+    {
+        $logger = new SpyLogger();
+        $violations = new ConstraintViolationList([
+            new ConstraintViolation('This value should not be blank.', null, [], '', 'name', null),
+        ]);
+
+        $indexer = $this->createIndexer($logger, passesFilter: true, violations: $violations);
+        $indexer->indexEntities([$this->createEntity()]);
+
+        $warning = $logger->firstOfLevel('warning');
+        self::assertNotNull($warning);
+        self::assertSame('42', $warning['context']['id']);
+        self::assertSame(['name: This value should not be blank.'], $warning['context']['violations']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_at_debug_when_an_entity_is_filtered_out(): void
+    {
+        $logger = new SpyLogger();
+
+        $indexer = $this->createIndexer($logger, passesFilter: false, violations: new ConstraintViolationList());
+        $indexer->indexEntities([$this->createEntity()]);
+
+        $debug = $logger->firstOfLevel('debug');
+        self::assertNotNull($debug);
+        self::assertSame('42', $debug['context']['id']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_a_batch_summary(): void
+    {
+        $logger = new SpyLogger();
+
+        $indexer = $this->createIndexer($logger, passesFilter: false, violations: new ConstraintViolationList());
+        $indexer->indexEntities([$this->createEntity()]);
+
+        $summary = $logger->firstOfLevel('info');
+        self::assertNotNull($summary);
+        self::assertSame(1, $summary['context']['mapped']);
+        self::assertSame(1, $summary['context']['filtered']);
+        self::assertSame(0, $summary['context']['invalid']);
+        self::assertSame(0, $summary['context']['indexed']);
+    }
+}

--- a/tests/Unit/Indexer/SpyLogger.php
+++ b/tests/Unit/Indexer/SpyLogger.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Indexer;
+
+use Psr\Log\AbstractLogger;
+
+final class SpyLogger extends AbstractLogger
+{
+    /** @var list<array{level: mixed, message: string, context: array<array-key, mixed>}> */
+    public array $records = [];
+
+    /**
+     * @param mixed $level
+     * @param array<array-key, mixed> $context
+     */
+    public function log($level, string|\Stringable $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level' => $level,
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * @return array{level: mixed, message: string, context: array<array-key, mixed>}|null
+     */
+    public function firstOfLevel(string $level): ?array
+    {
+        foreach ($this->records as $record) {
+            if ($record['level'] === $level) {
+                return $record;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## What

There was no logging anywhere in the indexing pipeline. The two silent `continue`s in `DefaultIndexer::indexEntities()` — object-filter rejection and **validator rejection** — meant a document with an invalid/missing required field simply vanished from the index with zero diagnostics. An entire catalog could fail to index with the only symptom being "search is empty".

This injects a `LoggerInterface` into `DefaultIndexer` and:
- logs each **validator rejection** at `warning` with the entity id and each violation message;
- logs **filter rejections** at `debug`;
- logs a per-scope **batch summary** at `info` (mapped / filtered / invalid / indexed).

The logger is routed to a dedicated `setono_sylius_meilisearch` Monolog channel via the `monolog.logger` tag when MonologBundle is installed, and falls back to the default `logger` service otherwise. It is an **optional** constructor argument defaulting to `NullLogger`, so subclasses of the (non-`final`) `DefaultIndexer` remain backwards compatible.

## Testing

`DefaultIndexerTest` (with a spy logger):
- a document failing validation produces a `warning` naming the entity id and each violation;
- a filtered-out entity produces a `debug` entry;
- a batch summary with the counts is logged.

Closes #128

---
_Stacked on #154 (#132)._