### PR TITLE
Apply enabled/stock default filters on the incremental indexing path

### DIFF
--- a/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
+++ b/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
@@ -16,7 +16,9 @@ use Setono\SyliusMeilisearchPlugin\EventSubscriber\IndexableDataFilter\ChannelsA
 use Setono\SyliusMeilisearchPlugin\EventSubscriber\IndexableDataFilter\EnabledFilter;
 use Setono\SyliusMeilisearchPlugin\EventSubscriber\IndexableDataFilter\StockAvailableFilter;
 use Setono\SyliusMeilisearchPlugin\Filter\Entity\ChannelsAwareEntityFilter;
+use Setono\SyliusMeilisearchPlugin\Filter\Entity\EnabledEntityFilter;
 use Setono\SyliusMeilisearchPlugin\Filter\Entity\EntityFilterInterface;
+use Setono\SyliusMeilisearchPlugin\Filter\Entity\StockAvailableEntityFilter;
 use Setono\SyliusMeilisearchPlugin\Form\Builder\FilterFormBuilderInterface;
 use Setono\SyliusMeilisearchPlugin\Form\Builder\Sorter\FilterValuesSorterInterface;
 use Setono\SyliusMeilisearchPlugin\Indexer\DefaultIndexer;
@@ -537,6 +539,11 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
             ->setArgument('$index', $indexName)
             ->addTag('kernel.event_subscriber')
         ;
+
+        $container->register(sprintf('setono_sylius_meilisearch.filter.entity.enabled.%s', $indexName), EnabledEntityFilter::class)
+            ->setArgument('$index', $indexName)
+            ->addTag('setono_sylius_meilisearch.entity_filter')
+        ;
     }
 
     /**
@@ -571,6 +578,11 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
         $container->register(sprintf('setono_sylius_meilisearch.event_subscriber.indexable_data_filter.stock_available.%s', $indexName), StockAvailableFilter::class)
             ->setArgument('$index', $indexName)
             ->addTag('kernel.event_subscriber')
+        ;
+
+        $container->register(sprintf('setono_sylius_meilisearch.filter.entity.stock_available.%s', $indexName), StockAvailableEntityFilter::class)
+            ->setArgument('$index', $indexName)
+            ->addTag('setono_sylius_meilisearch.entity_filter')
         ;
     }
 

--- a/src/Filter/Entity/EnabledEntityFilter.php
+++ b/src/Filter/Entity/EnabledEntityFilter.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Filter\Entity;
+
+use Setono\SyliusMeilisearchPlugin\Document\Document;
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Sylius\Component\Resource\Model\ToggleableInterface;
+
+/**
+ * The object-filter counterpart of the "enabled" query-builder subscriber, so incremental
+ * (Doctrine event) indexing applies the same rule as a full reindex: a disabled entity is
+ * filtered out (and, on the incremental path, removed from the index on its next save).
+ */
+final class EnabledEntityFilter implements EntityFilterInterface
+{
+    public function __construct(private readonly string $index)
+    {
+    }
+
+    public function filter(IndexableInterface $entity, Document $document, IndexScope $indexScope): bool
+    {
+        if ($indexScope->index->name !== $this->index) {
+            return true;
+        }
+
+        if (!$entity instanceof ToggleableInterface) {
+            return true;
+        }
+
+        return $entity->isEnabled();
+    }
+}

--- a/src/Filter/Entity/StockAvailableEntityFilter.php
+++ b/src/Filter/Entity/StockAvailableEntityFilter.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Filter\Entity;
+
+use Setono\SyliusMeilisearchPlugin\Document\Document;
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+/**
+ * The object-filter counterpart of the "stock_available" query-builder subscriber. A product is
+ * kept when it has at least one variant that is either untracked or has available stock
+ * (onHand - onHold > 0); otherwise it is filtered out (and removed from the index on save).
+ */
+final class StockAvailableEntityFilter implements EntityFilterInterface
+{
+    public function __construct(private readonly string $index)
+    {
+    }
+
+    public function filter(IndexableInterface $entity, Document $document, IndexScope $indexScope): bool
+    {
+        if ($indexScope->index->name !== $this->index) {
+            return true;
+        }
+
+        if (!$entity instanceof ProductInterface) {
+            return true;
+        }
+
+        foreach ($entity->getVariants() as $variant) {
+            if (!$variant instanceof ProductVariantInterface) {
+                continue;
+            }
+
+            if (!$variant->isTracked()) {
+                return true;
+            }
+
+            if (((int) $variant->getOnHand() - (int) $variant->getOnHold()) > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Indexer/DefaultIndexer.php
+++ b/src/Indexer/DefaultIndexer.php
@@ -75,6 +75,7 @@ class DefaultIndexer extends AbstractIndexer
             $uid = $this->indexNameResolver->resolveFromIndexScope($indexScope);
 
             $documents = [];
+            $documentsToRemove = [];
             $filtered = 0;
             $invalid = 0;
 
@@ -84,7 +85,15 @@ class DefaultIndexer extends AbstractIndexer
 
                 if (!$this->objectFilter->filter($entity, $document, $indexScope)) {
                     ++$filtered;
-                    $this->logger->debug('Entity was filtered out during indexing and will not be indexed', [
+
+                    // Actively remove a filtered-out entity from the index (e.g. a product that was
+                    // just disabled or went out of stock) instead of silently leaving a stale document.
+                    $documentIdentifier = $entity->getDocumentIdentifier();
+                    if (null !== $documentIdentifier) {
+                        $documentsToRemove[] = $documentIdentifier;
+                    }
+
+                    $this->logger->debug('Entity was filtered out during indexing and removed from the index if present', [
                         'index' => $uid,
                         'entity' => $entity::class,
                         'id' => $entity->getDocumentIdentifier(),
@@ -118,7 +127,12 @@ class DefaultIndexer extends AbstractIndexer
                 $documents[] = $data;
             }
 
-            $this->client->index($uid)->addDocuments($documents, 'id');
+            $meilisearchIndex = $this->client->index($uid);
+            $meilisearchIndex->addDocuments($documents, 'id');
+
+            if ([] !== $documentsToRemove) {
+                $meilisearchIndex->deleteDocuments($documentsToRemove);
+            }
 
             $this->logger->info('Indexed a batch of entities', [
                 'index' => $uid,
@@ -126,6 +140,7 @@ class DefaultIndexer extends AbstractIndexer
                 'filtered' => $filtered,
                 'invalid' => $invalid,
                 'indexed' => count($documents),
+                'removed' => count($documentsToRemove),
             ]);
         }
     }

--- a/tests/Unit/Filter/Entity/EnabledEntityFilterTest.php
+++ b/tests/Unit/Filter/Entity/EnabledEntityFilterTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Filter\Entity;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Document\Product as ProductDocument;
+use Setono\SyliusMeilisearchPlugin\Filter\Entity\EnabledEntityFilter;
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Setono\SyliusMeilisearchPlugin\Tests\Application\Entity\Product;
+use Sylius\Component\Resource\Model\ToggleableInterface;
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Filter\Entity\EnabledEntityFilter
+ */
+final class EnabledEntityFilterTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private function indexScope(string $indexName): IndexScope
+    {
+        return new IndexScope(new Index($indexName, ProductDocument::class, [Product::class], new Container()));
+    }
+
+    private function toggleable(bool $enabled): IndexableInterface
+    {
+        $entity = $this->prophesize(IndexableInterface::class);
+        $entity->willImplement(ToggleableInterface::class);
+        $entity->isEnabled()->willReturn($enabled);
+
+        return $entity->reveal();
+    }
+
+    /**
+     * @test
+     */
+    public function it_keeps_enabled_entities(): void
+    {
+        $filter = new EnabledEntityFilter('products');
+
+        self::assertTrue($filter->filter($this->toggleable(true), new ProductDocument(), $this->indexScope('products')));
+    }
+
+    /**
+     * @test
+     */
+    public function it_filters_out_disabled_entities(): void
+    {
+        $filter = new EnabledEntityFilter('products');
+
+        self::assertFalse($filter->filter($this->toggleable(false), new ProductDocument(), $this->indexScope('products')));
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_scopes_for_other_indexes(): void
+    {
+        $filter = new EnabledEntityFilter('products');
+
+        // Disabled, but the scope is for another index, so this filter does not apply
+        self::assertTrue($filter->filter($this->toggleable(false), new ProductDocument(), $this->indexScope('taxons')));
+    }
+
+    /**
+     * @test
+     */
+    public function it_keeps_non_toggleable_entities(): void
+    {
+        $filter = new EnabledEntityFilter('products');
+
+        self::assertTrue($filter->filter(
+            $this->prophesize(IndexableInterface::class)->reveal(),
+            new ProductDocument(),
+            $this->indexScope('products'),
+        ));
+    }
+}

--- a/tests/Unit/Filter/Entity/StockAvailableEntityFilterTest.php
+++ b/tests/Unit/Filter/Entity/StockAvailableEntityFilterTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Filter\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Document\Product as ProductDocument;
+use Setono\SyliusMeilisearchPlugin\Filter\Entity\StockAvailableEntityFilter;
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Setono\SyliusMeilisearchPlugin\Tests\Application\Entity\Product;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Filter\Entity\StockAvailableEntityFilter
+ */
+final class StockAvailableEntityFilterTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private function indexScope(): IndexScope
+    {
+        return new IndexScope(new Index('products', ProductDocument::class, [Product::class], new Container()));
+    }
+
+    private function variant(bool $tracked, int $onHand, int $onHold = 0): ProductVariantInterface
+    {
+        $variant = $this->prophesize(ProductVariantInterface::class);
+        $variant->isTracked()->willReturn($tracked);
+        $variant->getOnHand()->willReturn($onHand);
+        $variant->getOnHold()->willReturn($onHold);
+
+        return $variant->reveal();
+    }
+
+    private function product(ProductVariantInterface ...$variants): ProductInterface&IndexableInterface
+    {
+        $product = $this->prophesize(ProductInterface::class);
+        $product->willImplement(IndexableInterface::class);
+        $product->getVariants()->willReturn(new ArrayCollection($variants));
+
+        /** @var ProductInterface&IndexableInterface $revealed */
+        $revealed = $product->reveal();
+
+        return $revealed;
+    }
+
+    /**
+     * @test
+     */
+    public function it_keeps_a_product_with_an_in_stock_variant(): void
+    {
+        $filter = new StockAvailableEntityFilter('products');
+
+        self::assertTrue($filter->filter(
+            $this->product($this->variant(tracked: true, onHand: 5)),
+            new ProductDocument(),
+            $this->indexScope(),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_keeps_a_product_with_an_untracked_variant(): void
+    {
+        $filter = new StockAvailableEntityFilter('products');
+
+        self::assertTrue($filter->filter(
+            $this->product($this->variant(tracked: false, onHand: 0)),
+            new ProductDocument(),
+            $this->indexScope(),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_filters_out_a_product_whose_variants_are_all_tracked_and_out_of_stock(): void
+    {
+        $filter = new StockAvailableEntityFilter('products');
+
+        self::assertFalse($filter->filter(
+            $this->product(
+                $this->variant(tracked: true, onHand: 3, onHold: 3),
+                $this->variant(tracked: true, onHand: 0),
+            ),
+            new ProductDocument(),
+            $this->indexScope(),
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_filters_out_a_product_without_variants(): void
+    {
+        $filter = new StockAvailableEntityFilter('products');
+
+        self::assertFalse($filter->filter($this->product(), new ProductDocument(), $this->indexScope()));
+    }
+}

--- a/tests/Unit/Indexer/DefaultIndexerTest.php
+++ b/tests/Unit/Indexer/DefaultIndexerTest.php
@@ -55,6 +55,7 @@ final class DefaultIndexerTest extends TestCase
 
         $indexes = $this->prophesize(Indexes::class);
         $indexes->addDocuments(Argument::cetera())->willReturn([]);
+        $indexes->deleteDocuments(Argument::cetera())->willReturn([]);
 
         $client = $this->prophesize(Client::class);
         $client->index('products__test')->willReturn($indexes->reveal());
@@ -133,6 +134,49 @@ final class DefaultIndexerTest extends TestCase
         self::assertSame(1, $summary['context']['filtered']);
         self::assertSame(0, $summary['context']['invalid']);
         self::assertSame(0, $summary['context']['indexed']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_removes_a_filtered_out_entity_from_the_index(): void
+    {
+        $index = new Index('products', ProductDocument::class, [Product::class], new Container());
+        $indexScope = new IndexScope($index, 'FASHION_WEB', 'en_US', 'USD');
+
+        $indexScopeProvider = $this->prophesize(IndexScopeProviderInterface::class);
+        $indexScopeProvider->getAll($index)->willReturn([$indexScope]);
+
+        $uidResolver = $this->prophesize(IndexUidResolverInterface::class);
+        $uidResolver->resolveFromIndexScope($indexScope)->willReturn('products__test');
+
+        $objectFilter = $this->prophesize(EntityFilterInterface::class);
+        $objectFilter->filter(Argument::cetera())->willReturn(false);
+
+        $indexes = $this->prophesize(Indexes::class);
+        $indexes->addDocuments([], 'id')->shouldBeCalled()->willReturn([]);
+        // The filtered-out entity is removed from the index
+        $indexes->deleteDocuments(['42'])->shouldBeCalledOnce()->willReturn([]);
+
+        $client = $this->prophesize(Client::class);
+        $client->index('products__test')->willReturn($indexes->reveal());
+
+        $indexer = new DefaultIndexer(
+            $index,
+            $this->prophesize(ManagerRegistry::class)->reveal(),
+            $indexScopeProvider->reveal(),
+            $uidResolver->reveal(),
+            $this->prophesize(DataMapperInterface::class)->reveal(),
+            $this->prophesize(\Symfony\Component\Serializer\Normalizer\NormalizerInterface::class)->reveal(),
+            $client->reveal(),
+            $objectFilter->reveal(),
+            $this->prophesize(EventDispatcherInterface::class)->reveal(),
+            $this->prophesize(MessageBusInterface::class)->reveal(),
+            $this->prophesize(ValidatorInterface::class)->reveal(),
+            new SpyLogger(),
+        );
+
+        $indexer->indexEntities([$this->createEntity()]);
     }
 
     /**


### PR DESCRIPTION
## What

Full reindexing and incremental (Doctrine event) indexing used two different, inconsistent filter sets. The `enabled` / `stock_available` default filters only existed as **query-builder subscribers** (which run during full reindex), while the incremental path only ran the object filters tagged `setono_sylius_meilisearch.entity_filter` — of which only `channels_aware` had an object-filter counterpart. Consequences:
- editing a **disabled** product re-added it to the index;
- **disabling** a product didn't remove it (nothing on the incremental path ever deleted).

Two parts:
1. **Unify the filters.** Ship `EnabledEntityFilter` and `StockAvailableEntityFilter` (the object-filter counterparts of the `enabled` / `stock_available` query-builder subscribers), registered under the **same** per-index `default_filters` toggles as the subscribers — so the incremental path applies the same rules as the full reindex.
2. **Delete on filter failure.** In `DefaultIndexer::indexEntities()`, when an entity fails the object filter, its document is removed from that scope's index (batched per scope) instead of being silently skipped. So "disable a product" (or de-stock it) actively removes it from search on the very next save.

Full reindex already routes through `indexEntities`, but its entities are pre-filtered by the query-builder subscribers, so the object filters are consistent and no spurious deletes occur (verified: the functional `SearchTest` still passes).

## Testing

- `EnabledEntityFilterTest` / `StockAvailableEntityFilterTest`: full logic incl. other-index scopes, non-toggleable/non-product entities, untracked vs out-of-stock variants, no-variant products.
- `DefaultIndexerTest::it_removes_a_filtered_out_entity_from_the_index`: a filtered-out entity triggers `deleteDocuments([id])`.

Closes #112

---
_Stacked on #156 (#111)._