### PR TITLE
Make index dispatches failure-safe (and confirm async marker interface)

### DIFF
--- a/src/EventListener/Doctrine/EntityListener.php
+++ b/src/EventListener/Doctrine/EntityListener.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Setono\SyliusMeilisearchPlugin\EventListener\Doctrine;
 
 use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Setono\SyliusMeilisearchPlugin\Message\Command\IndexEntity;
 use Setono\SyliusMeilisearchPlugin\Message\Command\RemoveEntity;
 use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
@@ -24,6 +26,7 @@ final class EntityListener
 
     public function __construct(
         private readonly MessageBusInterface $commandBus,
+        private readonly LoggerInterface $logger = new NullLogger(),
     ) {
         $this->removeIndexableStorage = new SplObjectStorage();
     }
@@ -79,8 +82,20 @@ final class EntityListener
     {
         $indexable = self::extractIndexableFromEvent($eventArgs);
 
-        if (null !== $indexable) {
+        if (null === $indexable) {
+            return;
+        }
+
+        try {
             $this->commandBus->dispatch($message($indexable));
+        } catch (\Throwable $e) {
+            // A search-index update (or its transport being unavailable) must never break the
+            // entity save it is reacting to. Swallow and log instead.
+            $this->logger->error('Failed to dispatch a Meilisearch indexing command for an entity change: {message}', [
+                'message' => $e->getMessage(),
+                'entity' => $indexable::class,
+                'exception' => $e,
+            ]);
         }
     }
 

--- a/src/Resources/config/services/event_listener.xml
+++ b/src/Resources/config/services/event_listener.xml
@@ -5,11 +5,13 @@
         <!-- Doctrine specific event subscribers -->
         <service id="Setono\SyliusMeilisearchPlugin\EventListener\Doctrine\EntityListener">
             <argument type="service" id="setono_sylius_meilisearch.command_bus"/>
+            <argument type="service" id="logger"/>
 
             <tag name="doctrine.event_listener" event="postPersist"/>
             <tag name="doctrine.event_listener" event="postUpdate"/>
             <tag name="doctrine.event_listener" event="preRemove"/>
             <tag name="doctrine.event_listener" event="postRemove"/>
+            <tag name="monolog.logger" channel="setono_sylius_meilisearch"/>
         </service>
 
         <service id="Setono\SyliusMeilisearchPlugin\EventListener\Doctrine\SynonymListener">

--- a/tests/Unit/EventListener/Doctrine/EntityListenerTest.php
+++ b/tests/Unit/EventListener/Doctrine/EntityListenerTest.php
@@ -12,6 +12,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Setono\SyliusMeilisearchPlugin\EventListener\Doctrine\EntityListener;
 use Setono\SyliusMeilisearchPlugin\Message\Command\RemoveEntity;
 use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Setono\SyliusMeilisearchPlugin\Tests\Unit\Indexer\SpyLogger;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -49,5 +50,29 @@ final class EntityListenerTest extends TestCase
 
         self::assertInstanceOf(\Countable::class, $storage);
         self::assertCount(0, $storage, 'The SplObjectStorage must not retain the entity after postRemove');
+    }
+
+    /**
+     * @test
+     */
+    public function it_swallows_and_logs_a_failing_dispatch_so_the_entity_save_still_succeeds(): void
+    {
+        $entity = $this->prophesize(IndexableInterface::class);
+        $entity->getId()->willReturn(7);
+        $entity->getDocumentIdentifier()->willReturn('7');
+
+        $eventArgs = new LifecycleEventArgs($entity->reveal(), $this->prophesize(ObjectManager::class)->reveal());
+
+        $commandBus = $this->prophesize(MessageBusInterface::class);
+        $commandBus->dispatch(Argument::any())->willThrow(new \RuntimeException('Meilisearch is down'));
+
+        $logger = new SpyLogger();
+        $listener = new EntityListener($commandBus->reveal(), $logger);
+
+        // Must not throw, even though the dispatch fails
+        $listener->postPersist($eventArgs);
+
+        $error = $logger->firstOfLevel('error');
+        self::assertNotNull($error);
     }
 }


### PR DESCRIPTION
## What

Out of the box every save of an indexable entity dispatches on the plugin's command bus, and since no transport routing is configured, the handler runs **synchronously inside the Doctrine flush**. If Meilisearch was slow or down, **saving/deleting a product failed** — a search-index hiccup broke catalog management.

Two parts:
1. **Resilience for the sync default.** `EntityListener` now wraps every dispatch in `try/catch` and logs the failure at `error` (dedicated `setono_sylius_meilisearch` Monolog channel). A failed index update — or a transport outage on an async setup — can never break the entity save it reacts to.
2. **First-class async support.** All plugin command messages already share the `CommandInterface` marker (directly or via `EntityAwareCommand`), so a single `framework.messenger.routing` entry can route everything to an async transport. The recommended routing snippet is documented in the operational-model docs issue (#140).

## Testing

`EntityListenerTest::it_swallows_and_logs_a_failing_dispatch_so_the_entity_save_still_succeeds`: with the command bus throwing, `postPersist` does not throw and an `error` is logged.

Closes #124

---
_Stacked on #157 (#112)._