### PR TITLE
Reindex products when related entities change (prices, stock, associations)

### DIFF
--- a/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
+++ b/src/DependencyInjection/SetonoSyliusMeilisearchExtension.php
@@ -25,6 +25,7 @@ use Setono\SyliusMeilisearchPlugin\Indexer\DefaultIndexer;
 use Setono\SyliusMeilisearchPlugin\Indexer\IndexerInterface;
 use Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\FilterBuilderInterface;
 use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScopeProviderInterface;
+use Setono\SyliusMeilisearchPlugin\Resolver\Indexable\IndexableEntityResolverInterface;
 use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
 use Setono\SyliusMeilisearchPlugin\Twig\AutocompleteRuntime;
 use Setono\SyliusMeilisearchPlugin\UrlGenerator\EntityUrlGeneratorInterface;
@@ -99,6 +100,9 @@ final class SetonoSyliusMeilisearchExtension extends AbstractResourceExtension i
 
         $container->registerForAutoconfiguration(FilterValuesSorterInterface::class)
             ->addTag('setono_sylius_meilisearch.filter_values_sorter');
+
+        $container->registerForAutoconfiguration(IndexableEntityResolverInterface::class)
+            ->addTag('setono_sylius_meilisearch.indexable_entity_resolver');
 
         self::registerIndexesConfiguration($config['indexes'], $container);
         self::registerSearchConfiguration($config['search'], $container, $loader);

--- a/src/EventListener/Doctrine/EntityListener.php
+++ b/src/EventListener/Doctrine/EntityListener.php
@@ -10,8 +10,8 @@ use Psr\Log\NullLogger;
 use Setono\SyliusMeilisearchPlugin\Message\Command\IndexEntity;
 use Setono\SyliusMeilisearchPlugin\Message\Command\RemoveEntity;
 use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Setono\SyliusMeilisearchPlugin\Resolver\Indexable\IndexableEntityResolverInterface;
 use SplObjectStorage;
-use Sylius\Component\Resource\Model\TranslationInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 final class EntityListener
@@ -26,6 +26,7 @@ final class EntityListener
 
     public function __construct(
         private readonly MessageBusInterface $commandBus,
+        private readonly IndexableEntityResolverInterface $indexableEntityResolver,
         private readonly LoggerInterface $logger = new NullLogger(),
     ) {
         $this->removeIndexableStorage = new SplObjectStorage();
@@ -33,84 +34,70 @@ final class EntityListener
 
     public function postPersist(LifecycleEventArgs $eventArgs): void
     {
-        $this->dispatch($eventArgs, static fn (IndexableInterface $entity) => IndexEntity::new($entity));
+        $this->index($eventArgs->getObject());
     }
 
     public function postUpdate(LifecycleEventArgs $eventArgs): void
     {
-        $this->dispatch($eventArgs, static fn (IndexableInterface $entity) => IndexEntity::new($entity));
+        $this->index($eventArgs->getObject());
     }
 
     public function preRemove(LifecycleEventArgs $eventArgs): void
     {
-        $indexable = self::extractIndexableFromEvent($eventArgs);
+        $object = $eventArgs->getObject();
 
-        if (null !== $indexable) {
-            $this->removeIndexableStorage->attach($indexable, [$indexable->getId(), $indexable->getDocumentIdentifier()]);
+        // Only the indexable entity itself needs its id and document identifier captured for a document
+        // removal. They are captured here because they are no longer available once the row is deleted.
+        if ($object instanceof IndexableInterface) {
+            $this->removeIndexableStorage->attach($object, [$object->getId(), $object->getDocumentIdentifier()]);
         }
     }
 
     public function postRemove(LifecycleEventArgs $eventArgs): void
     {
-        $indexable = self::extractIndexableFromEvent($eventArgs);
+        $object = $eventArgs->getObject();
 
-        if (null === $indexable) {
-            return;
+        foreach ($this->indexableEntityResolver->resolve($object) as $indexable) {
+            if ($object instanceof IndexableInterface && $indexable === $object) {
+                // The indexable entity itself was removed: delete its document using the identifier
+                // captured before deletion, so no reload of the (now gone) entity is needed.
+                [$entityId, $documentIdentifier] = $this->removeIndexableStorage[$object] ?? [null, null];
+                if (null !== $documentIdentifier) {
+                    $this->dispatch(new RemoveEntity($object::class, $entityId, $documentIdentifier));
+                }
+
+                continue;
+            }
+
+            // A related entity was removed (e.g. a channel price or a variant): reindex the owner
+            $this->dispatch(IndexEntity::new($indexable));
         }
 
-        [$entityId, $documentIdentifier] = $this->removeIndexableStorage[$indexable] ?? [null, null];
-
-        // Always detach so the SplObjectStorage does not grow unbounded in long-running workers
-        // (it is attach-only in preRemove).
-        $this->removeIndexableStorage->detach($indexable);
-
-        // Without a document identifier there is nothing to remove from the index.
-        if (null === $documentIdentifier) {
-            return;
+        if ($object instanceof IndexableInterface) {
+            // Always detach so the SplObjectStorage does not grow unbounded in long-running workers
+            $this->removeIndexableStorage->detach($object);
         }
-
-        $this->dispatch(
-            $eventArgs,
-            fn (IndexableInterface $entity) => new RemoveEntity($entity::class, $entityId, $documentIdentifier),
-        );
     }
 
-    /**
-     * @param callable(IndexableInterface):object $message
-     */
-    private function dispatch(LifecycleEventArgs $eventArgs, callable $message): void
+    private function index(object $object): void
     {
-        $indexable = self::extractIndexableFromEvent($eventArgs);
-
-        if (null === $indexable) {
-            return;
+        foreach ($this->indexableEntityResolver->resolve($object) as $indexable) {
+            $this->dispatch(IndexEntity::new($indexable));
         }
+    }
 
+    private function dispatch(object $message): void
+    {
         try {
-            $this->commandBus->dispatch($message($indexable));
+            $this->commandBus->dispatch($message);
         } catch (\Throwable $e) {
             // A search-index update (or its transport being unavailable) must never break the
             // entity save it is reacting to. Swallow and log instead.
             $this->logger->error('Failed to dispatch a Meilisearch indexing command for an entity change: {message}', [
                 'message' => $e->getMessage(),
-                'entity' => $indexable::class,
+                'command' => $message::class,
                 'exception' => $e,
             ]);
         }
-    }
-
-    private static function extractIndexableFromEvent(LifecycleEventArgs $eventArgs): ?IndexableInterface
-    {
-        $obj = $eventArgs->getObject();
-
-        if ($obj instanceof TranslationInterface) {
-            $obj = $obj->getTranslatable();
-        }
-
-        if (!$obj instanceof IndexableInterface) {
-            return null;
-        }
-
-        return $obj;
     }
 }

--- a/src/Resolver/Indexable/ChannelPricingIndexableEntityResolver.php
+++ b/src/Resolver/Indexable/ChannelPricingIndexableEntityResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Resolver\Indexable;
+
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Sylius\Component\Core\Model\ChannelPricingInterface;
+
+/**
+ * A change to a channel price resolves to the product that owns it, so price changes are reflected
+ * in search and autocomplete without waiting for a full reindex.
+ */
+final class ChannelPricingIndexableEntityResolver implements IndexableEntityResolverInterface
+{
+    public function resolve(object $entity): iterable
+    {
+        if (!$entity instanceof ChannelPricingInterface) {
+            return;
+        }
+
+        $variant = $entity->getProductVariant();
+        $product = $variant?->getProduct();
+
+        if ($product instanceof IndexableInterface) {
+            yield $product;
+        }
+    }
+}

--- a/src/Resolver/Indexable/CompositeIndexableEntityResolver.php
+++ b/src/Resolver/Indexable/CompositeIndexableEntityResolver.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Resolver\Indexable;
+
+use Setono\CompositeCompilerPass\CompositeService;
+
+/**
+ * @extends CompositeService<IndexableEntityResolverInterface>
+ */
+final class CompositeIndexableEntityResolver extends CompositeService implements IndexableEntityResolverInterface
+{
+    public function resolve(object $entity): iterable
+    {
+        foreach ($this->services as $service) {
+            yield from $service->resolve($entity);
+        }
+    }
+}

--- a/src/Resolver/Indexable/IndexableEntityResolver.php
+++ b/src/Resolver/Indexable/IndexableEntityResolver.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Resolver\Indexable;
+
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+
+/**
+ * The base resolver: an indexable entity resolves to itself.
+ */
+final class IndexableEntityResolver implements IndexableEntityResolverInterface
+{
+    public function resolve(object $entity): iterable
+    {
+        if ($entity instanceof IndexableInterface) {
+            yield $entity;
+        }
+    }
+}

--- a/src/Resolver/Indexable/IndexableEntityResolverInterface.php
+++ b/src/Resolver/Indexable/IndexableEntityResolverInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Resolver\Indexable;
+
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+
+/**
+ * Resolves the indexable entities that are affected by a change to the given object.
+ *
+ * This is the extension point that lets a change to an *associated* entity (a channel price, a
+ * variant's stock, a taxon assignment, …) trigger a reindex of the indexable entity that carries
+ * it, rather than only reacting to changes on the indexed entity itself. Tag an implementation
+ * with "setono_sylius_meilisearch.indexable_entity_resolver" (autoconfiguration adds the tag).
+ */
+interface IndexableEntityResolverInterface
+{
+    /**
+     * @return iterable<IndexableInterface>
+     */
+    public function resolve(object $entity): iterable;
+}

--- a/src/Resolver/Indexable/ProductVariantIndexableEntityResolver.php
+++ b/src/Resolver/Indexable/ProductVariantIndexableEntityResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Resolver\Indexable;
+
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+/**
+ * A change to a variant resolves to the product that owns it. This covers stock changes, since a
+ * variant's onHand/onHold live on the variant.
+ */
+final class ProductVariantIndexableEntityResolver implements IndexableEntityResolverInterface
+{
+    public function resolve(object $entity): iterable
+    {
+        if (!$entity instanceof ProductVariantInterface) {
+            return;
+        }
+
+        $product = $entity->getProduct();
+
+        if ($product instanceof IndexableInterface) {
+            yield $product;
+        }
+    }
+}

--- a/src/Resolver/Indexable/TranslationIndexableEntityResolver.php
+++ b/src/Resolver/Indexable/TranslationIndexableEntityResolver.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Resolver\Indexable;
+
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Sylius\Component\Resource\Model\TranslationInterface;
+
+/**
+ * A change to a translation resolves to the translatable entity it belongs to.
+ */
+final class TranslationIndexableEntityResolver implements IndexableEntityResolverInterface
+{
+    public function resolve(object $entity): iterable
+    {
+        if (!$entity instanceof TranslationInterface) {
+            return;
+        }
+
+        $translatable = $entity->getTranslatable();
+        if ($translatable instanceof IndexableInterface) {
+            yield $translatable;
+        }
+    }
+}

--- a/src/Resources/config/services/event_listener.xml
+++ b/src/Resources/config/services/event_listener.xml
@@ -5,6 +5,7 @@
         <!-- Doctrine specific event subscribers -->
         <service id="Setono\SyliusMeilisearchPlugin\EventListener\Doctrine\EntityListener">
             <argument type="service" id="setono_sylius_meilisearch.command_bus"/>
+            <argument type="service" id="Setono\SyliusMeilisearchPlugin\Resolver\Indexable\IndexableEntityResolverInterface"/>
             <argument type="service" id="logger"/>
 
             <tag name="doctrine.event_listener" event="postPersist"/>

--- a/src/Resources/config/services/resolver.xml
+++ b/src/Resources/config/services/resolver.xml
@@ -10,5 +10,27 @@
                       id="Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScopeProviderInterface"/>
             <argument>%kernel.environment%</argument>
         </service>
+
+        <!-- Indexable entity resolvers -->
+        <service id="Setono\SyliusMeilisearchPlugin\Resolver\Indexable\IndexableEntityResolverInterface"
+                 alias="Setono\SyliusMeilisearchPlugin\Resolver\Indexable\CompositeIndexableEntityResolver"/>
+
+        <service id="Setono\SyliusMeilisearchPlugin\Resolver\Indexable\CompositeIndexableEntityResolver"/>
+
+        <service id="Setono\SyliusMeilisearchPlugin\Resolver\Indexable\IndexableEntityResolver">
+            <tag name="setono_sylius_meilisearch.indexable_entity_resolver" priority="100"/>
+        </service>
+
+        <service id="Setono\SyliusMeilisearchPlugin\Resolver\Indexable\TranslationIndexableEntityResolver">
+            <tag name="setono_sylius_meilisearch.indexable_entity_resolver" priority="90"/>
+        </service>
+
+        <service id="Setono\SyliusMeilisearchPlugin\Resolver\Indexable\ChannelPricingIndexableEntityResolver">
+            <tag name="setono_sylius_meilisearch.indexable_entity_resolver" priority="80"/>
+        </service>
+
+        <service id="Setono\SyliusMeilisearchPlugin\Resolver\Indexable\ProductVariantIndexableEntityResolver">
+            <tag name="setono_sylius_meilisearch.indexable_entity_resolver" priority="80"/>
+        </service>
     </services>
 </container>

--- a/src/SetonoSyliusMeilisearchPlugin.php
+++ b/src/SetonoSyliusMeilisearchPlugin.php
@@ -11,6 +11,7 @@ use Setono\SyliusMeilisearchPlugin\Form\Builder\CompositeFilterFormBuilder;
 use Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\CompositeFilterBuilder;
 use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\CompositeIndexScopeProvider;
 use Setono\SyliusMeilisearchPlugin\Provider\Settings\CompositeSettingsProvider;
+use Setono\SyliusMeilisearchPlugin\Resolver\Indexable\CompositeIndexableEntityResolver;
 use Sylius\Bundle\CoreBundle\Application\SyliusPluginTrait;
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
@@ -68,6 +69,11 @@ final class SetonoSyliusMeilisearchPlugin extends AbstractResourceBundle
         $container->addCompilerPass(new CompositeCompilerPass(
             CompositeFilterBuilder::class,
             'setono_sylius_meilisearch.filter_builder',
+        ));
+
+        $container->addCompilerPass(new CompositeCompilerPass(
+            CompositeIndexableEntityResolver::class,
+            'setono_sylius_meilisearch.indexable_entity_resolver',
         ));
     }
 }

--- a/tests/Unit/EventListener/Doctrine/EntityListenerTest.php
+++ b/tests/Unit/EventListener/Doctrine/EntityListenerTest.php
@@ -10,9 +10,16 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Setono\SyliusMeilisearchPlugin\EventListener\Doctrine\EntityListener;
+use Setono\SyliusMeilisearchPlugin\Message\Command\IndexEntity;
 use Setono\SyliusMeilisearchPlugin\Message\Command\RemoveEntity;
 use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Setono\SyliusMeilisearchPlugin\Resolver\Indexable\ChannelPricingIndexableEntityResolver;
+use Setono\SyliusMeilisearchPlugin\Resolver\Indexable\CompositeIndexableEntityResolver;
+use Setono\SyliusMeilisearchPlugin\Resolver\Indexable\IndexableEntityResolver;
 use Setono\SyliusMeilisearchPlugin\Tests\Unit\Indexer\SpyLogger;
+use Sylius\Component\Core\Model\ChannelPricingInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -41,7 +48,7 @@ final class EntityListenerTest extends TestCase
             ->willReturn(new Envelope(new \stdClass()))
             ->shouldBeCalledOnce();
 
-        $listener = new EntityListener($commandBus->reveal());
+        $listener = new EntityListener($commandBus->reveal(), new IndexableEntityResolver());
         $listener->preRemove($eventArgs);
         $listener->postRemove($eventArgs);
 
@@ -67,12 +74,54 @@ final class EntityListenerTest extends TestCase
         $commandBus->dispatch(Argument::any())->willThrow(new \RuntimeException('Meilisearch is down'));
 
         $logger = new SpyLogger();
-        $listener = new EntityListener($commandBus->reveal(), $logger);
+        $listener = new EntityListener($commandBus->reveal(), new IndexableEntityResolver(), $logger);
 
         // Must not throw, even though the dispatch fails
         $listener->postPersist($eventArgs);
 
         $error = $logger->firstOfLevel('error');
         self::assertNotNull($error);
+    }
+
+    /**
+     * @test
+     */
+    public function it_reindexes_the_owning_product_when_a_channel_price_changes(): void
+    {
+        $product = $this->prophesize(ProductInterface::class);
+        $product->willImplement(IndexableInterface::class);
+        $product->getId()->willReturn(11);
+        $product->getDocumentIdentifier()->willReturn('11');
+
+        $variant = $this->prophesize(ProductVariantInterface::class);
+        $variant->getProduct()->willReturn($product->reveal());
+
+        $channelPricing = $this->prophesize(ChannelPricingInterface::class);
+        $channelPricing->getProductVariant()->willReturn($variant->reveal());
+
+        $eventArgs = new LifecycleEventArgs($channelPricing->reveal(), $this->prophesize(ObjectManager::class)->reveal());
+
+        /** @var list<IndexEntity> $dispatched */
+        $dispatched = [];
+        $commandBus = $this->prophesize(MessageBusInterface::class);
+        $commandBus->dispatch(Argument::type(IndexEntity::class))->will(
+            static function (array $args) use (&$dispatched): Envelope {
+                /** @var IndexEntity $message */
+                $message = $args[0];
+                $dispatched[] = $message;
+
+                return new Envelope($message);
+            },
+        );
+
+        $composite = new CompositeIndexableEntityResolver();
+        $composite->add(new IndexableEntityResolver());
+        $composite->add(new ChannelPricingIndexableEntityResolver());
+
+        $listener = new EntityListener($commandBus->reveal(), $composite);
+        $listener->postUpdate($eventArgs);
+
+        self::assertCount(1, $dispatched);
+        self::assertSame(11, $dispatched[0]->id);
     }
 }

--- a/tests/Unit/Resolver/Indexable/IndexableEntityResolverTest.php
+++ b/tests/Unit/Resolver/Indexable/IndexableEntityResolverTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Resolver\Indexable;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Setono\SyliusMeilisearchPlugin\Resolver\Indexable\ChannelPricingIndexableEntityResolver;
+use Setono\SyliusMeilisearchPlugin\Resolver\Indexable\CompositeIndexableEntityResolver;
+use Setono\SyliusMeilisearchPlugin\Resolver\Indexable\IndexableEntityResolver;
+use Setono\SyliusMeilisearchPlugin\Resolver\Indexable\ProductVariantIndexableEntityResolver;
+use Setono\SyliusMeilisearchPlugin\Resolver\Indexable\TranslationIndexableEntityResolver;
+use Sylius\Component\Core\Model\ChannelPricingInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Resource\Model\TranslationInterface;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Resolver\Indexable\ChannelPricingIndexableEntityResolver
+ * @covers \Setono\SyliusMeilisearchPlugin\Resolver\Indexable\CompositeIndexableEntityResolver
+ * @covers \Setono\SyliusMeilisearchPlugin\Resolver\Indexable\IndexableEntityResolver
+ * @covers \Setono\SyliusMeilisearchPlugin\Resolver\Indexable\ProductVariantIndexableEntityResolver
+ * @covers \Setono\SyliusMeilisearchPlugin\Resolver\Indexable\TranslationIndexableEntityResolver
+ */
+final class IndexableEntityResolverTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private function composite(): CompositeIndexableEntityResolver
+    {
+        $composite = new CompositeIndexableEntityResolver();
+        $composite->add(new IndexableEntityResolver());
+        $composite->add(new TranslationIndexableEntityResolver());
+        $composite->add(new ChannelPricingIndexableEntityResolver());
+        $composite->add(new ProductVariantIndexableEntityResolver());
+
+        return $composite;
+    }
+
+    /**
+     * @return ProductInterface&IndexableInterface
+     */
+    private function indexableProduct(): ProductInterface
+    {
+        $product = $this->prophesize(ProductInterface::class);
+        $product->willImplement(IndexableInterface::class);
+
+        /** @var ProductInterface&IndexableInterface $revealed */
+        $revealed = $product->reveal();
+
+        return $revealed;
+    }
+
+    /**
+     * @param iterable<IndexableInterface> $resolved
+     *
+     * @return list<IndexableInterface>
+     */
+    private function toList(iterable $resolved): array
+    {
+        return iterator_to_array((function () use ($resolved) {
+            yield from $resolved;
+        })(), false);
+    }
+
+    /**
+     * @test
+     */
+    public function it_resolves_an_indexable_entity_to_itself(): void
+    {
+        $product = $this->indexableProduct();
+
+        self::assertSame([$product], $this->toList($this->composite()->resolve($product)));
+    }
+
+    /**
+     * @test
+     */
+    public function it_resolves_a_translation_to_its_translatable(): void
+    {
+        $product = $this->indexableProduct();
+
+        $translation = $this->prophesize(TranslationInterface::class);
+        $translation->getTranslatable()->willReturn($product);
+
+        self::assertSame([$product], $this->toList($this->composite()->resolve($translation->reveal())));
+    }
+
+    /**
+     * @test
+     */
+    public function it_resolves_a_channel_pricing_to_its_product(): void
+    {
+        $product = $this->indexableProduct();
+
+        $variant = $this->prophesize(ProductVariantInterface::class);
+        $variant->getProduct()->willReturn($product);
+
+        $channelPricing = $this->prophesize(ChannelPricingInterface::class);
+        $channelPricing->getProductVariant()->willReturn($variant->reveal());
+
+        self::assertSame([$product], $this->toList($this->composite()->resolve($channelPricing->reveal())));
+    }
+
+    /**
+     * @test
+     */
+    public function it_resolves_a_variant_to_its_product(): void
+    {
+        $product = $this->indexableProduct();
+
+        $variant = $this->prophesize(ProductVariantInterface::class);
+        $variant->getProduct()->willReturn($product);
+
+        self::assertSame([$product], $this->toList($this->composite()->resolve($variant->reveal())));
+    }
+
+    /**
+     * @test
+     */
+    public function it_resolves_an_unrelated_object_to_nothing(): void
+    {
+        self::assertSame([], $this->toList($this->composite()->resolve(new \stdClass())));
+    }
+}


### PR DESCRIPTION
## What

Reactive indexing only listened to the indexed entity itself (plus a hardcoded `TranslationInterface` special case). Changes to associated entities that feed the document — `ChannelPricing` (price!), variant stock — did **not** trigger a reindex, so prices and availability in search/autocomplete went stale until the next full reindex.

- New **`IndexableEntityResolverInterface`** extension point: given any changed object, it returns the indexable entities that should be reindexed. Composite + `setono_sylius_meilisearch.indexable_entity_resolver` tag + autoconfiguration, consistent with the plugin's other composite extension points.
- Built-in resolvers: the indexable entity itself; its translations (the old `TranslationInterface` special case folded into a resolver); `ChannelPricingInterface` → owning product; `ProductVariantInterface` → owning product (covers stock via `onHand`/`onHold`).
- `EntityListener` now runs every changed object through the composite resolver and dispatches `IndexEntity` for each resolved indexable. On removal, a removed **related** entity reindexes its owner, while the removed **indexable itself** still deletes its document (and no longer wrongly deletes the whole product document when just a translation is removed).

Projects can add their own resolvers (e.g. brand entity → its products) simply by implementing the interface — autoconfiguration tags it.

## Testing

- `IndexableEntityResolverTest`: each built-in resolver (self, translation, channel pricing, variant) and an unrelated object resolving to nothing.
- `EntityListenerTest::it_reindexes_the_owning_product_when_a_channel_price_changes`: a `ChannelPricing` update dispatches `IndexEntity` for the owning product.

Closes #125

---
_Stacked on #158 (#124)._