### PR TITLE
Reduce memory and query load of full reindexing

### DIFF
--- a/src/DataMapper/Product/PopularityDataMapper.php
+++ b/src/DataMapper/Product/PopularityDataMapper.php
@@ -21,6 +21,17 @@ final class PopularityDataMapper implements DataMapperInterface
 {
     use ORMTrait;
 
+    /**
+     * Popularity does not vary by scope (channel/locale/currency), but map() is called once per
+     * scope for every entity in a batch. Memoize the computed value per product object so the
+     * COUNT query runs once per product rather than once per product × scope. Keying on the object
+     * (via a WeakMap) means the cache is bounded and drops entries automatically once a batch's
+     * entities are detached by EntityManager::clear() and garbage collected.
+     *
+     * @var \WeakMap<object, int>
+     */
+    private \WeakMap $popularityCache;
+
     public function __construct(
         ManagerRegistry $managerRegistry,
         /** @var class-string $orderClass */
@@ -30,6 +41,7 @@ final class PopularityDataMapper implements DataMapperInterface
         private readonly string $popularityLookBackPeriod = '3 months',
     ) {
         $this->managerRegistry = $managerRegistry;
+        $this->popularityCache = new \WeakMap();
     }
 
     /**
@@ -43,9 +55,18 @@ final class PopularityDataMapper implements DataMapperInterface
             'The given $source and $target is not supported',
         );
 
+        if (!isset($this->popularityCache[$source])) {
+            $this->popularityCache[$source] = $this->calculatePopularity($source);
+        }
+
+        $target->popularity = $this->popularityCache[$source];
+    }
+
+    private function calculatePopularity(ProductInterface $source): int
+    {
         $variants = $source->getEnabledVariants()->map(static fn (ProductVariantInterface $variant): int => (int) $variant->getId())->toArray();
         if ([] === $variants) {
-            return;
+            return 0;
         }
 
         $orderIdLowerBound = $this->getOrderIdLowerBound();
@@ -66,7 +87,7 @@ final class PopularityDataMapper implements DataMapperInterface
             ->setParameter('variants', $variants)
         ;
 
-        $target->popularity = (int) $qb->getQuery()->getSingleScalarResult();
+        return (int) $qb->getQuery()->getSingleScalarResult();
     }
 
     /**

--- a/src/Indexer/DefaultIndexer.php
+++ b/src/Indexer/DefaultIndexer.php
@@ -128,7 +128,12 @@ class DefaultIndexer extends AbstractIndexer
             }
 
             $meilisearchIndex = $this->client->index($uid);
-            $meilisearchIndex->addDocuments($documents, 'id');
+
+            // Skip the addDocuments call for an empty batch (e.g. everything was filtered out)
+            // so we don't create pointless empty Meilisearch tasks.
+            if ([] !== $documents) {
+                $meilisearchIndex->addDocuments($documents, 'id');
+            }
 
             if ([] !== $documentsToRemove) {
                 $meilisearchIndex->deleteDocuments($documentsToRemove);

--- a/src/Message/Handler/IndexEntitiesHandler.php
+++ b/src/Message/Handler/IndexEntitiesHandler.php
@@ -37,5 +37,9 @@ final class IndexEntitiesHandler
         foreach ($this->indexRegistry->getByEntity($message->class) as $index) {
             $index->indexer()->indexEntities($entities);
         }
+
+        // Detach the batch's entities so a synchronous full reindex does not accumulate the whole
+        // catalog in memory in one process.
+        $this->getManager($message->class)->clear();
     }
 }

--- a/tests/Functional/DataMapper/Product/PopularityDataMapperTest.php
+++ b/tests/Functional/DataMapper/Product/PopularityDataMapperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Setono\SyliusMeilisearchPlugin\Tests\Functional\DataMapper\Product;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Setono\SyliusMeilisearchPlugin\Config\Index;
 use Setono\SyliusMeilisearchPlugin\DataMapper\Product\PopularityDataMapper;
 use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
@@ -85,6 +86,12 @@ final class PopularityDataMapperTest extends FunctionalTestCase
 
         $this->manager->flush();
 
+        // Reload the product from the database so it is a fully-hydrated managed entity, exactly
+        // as it is when the indexer maps it in production. Constructing entities in memory and
+        // flushing does not reliably back-populate generated ids on every supported Doctrine ORM
+        // version (e.g. 2.14), which would leave the variant id null and skew the query.
+        $product = $this->reloadProductByCode('popularity-test-product');
+
         /** @var PopularityDataMapper $dataMapper */
         $dataMapper = self::getContainer()->get(PopularityDataMapper::class);
 
@@ -99,6 +106,76 @@ final class PopularityDataMapperTest extends FunctionalTestCase
         // unpaid order is excluded, so the old SUM(quantity) implementation would have
         // produced 203 here.
         self::assertSame(4.0, $document->popularity);
+    }
+
+    public function testItMemoizesPopularityAcrossScopes(): void
+    {
+        /** @var ChannelRepositoryInterface $channelRepository */
+        $channelRepository = self::getContainer()->get('sylius.repository.channel');
+        /** @var ChannelInterface $channel */
+        $channel = $channelRepository->findOneByCode('FASHION_WEB');
+
+        $product = new Product();
+        $product->setCode('popularity-memoization-product');
+        $product->setEnabled(true);
+
+        $variant = new ProductVariant();
+        $variant->setCode('popularity-memoization-variant');
+        $variant->setEnabled(true);
+        $variant->setPosition(0);
+        $product->addVariant($variant);
+
+        $this->manager->persist($product);
+        $this->manager->persist($variant);
+
+        $this->createOrder($channel, $variant, 1, OrderPaymentStates::STATE_PAID);
+        $this->manager->flush();
+
+        // See the note in testItCountsDistinctPaidOrdersAndIgnoresQuantity: reload so the product
+        // is a managed entity with populated ids, mirroring how the indexer maps it in production.
+        $product = $this->reloadProductByCode('popularity-memoization-product');
+
+        // Use a dedicated mapper instance so this white-box assertion on the private memoization
+        // cache is isolated: the container-shared mapper is also invoked by the Doctrine flush
+        // listener when it reindexes the flushed product, which would leave extra cache entries.
+        /** @var ManagerRegistry $managerRegistry */
+        $managerRegistry = self::getContainer()->get('doctrine');
+        /** @var class-string $orderClass */
+        $orderClass = self::getContainer()->getParameter('sylius.model.order.class');
+        /** @var class-string $orderItemClass */
+        $orderItemClass = self::getContainer()->getParameter('sylius.model.order_item.class');
+        $dataMapper = new PopularityDataMapper($managerRegistry, $orderClass, $orderItemClass);
+
+        /** @var Index $index */
+        $index = self::getContainer()->get('setono_sylius_meilisearch.index.products');
+
+        // Popularity does not vary by scope, so mapping the same product for two currency scopes
+        // must produce the same value and only compute it once (memoized per product object).
+        $document1 = new ProductDocument();
+        $dataMapper->map($product, $document1, new IndexScope($index, 'FASHION_WEB', 'en_US', 'USD'));
+
+        $document2 = new ProductDocument();
+        $dataMapper->map($product, $document2, new IndexScope($index, 'FASHION_WEB', 'en_US', 'EUR'));
+
+        self::assertSame(1.0, $document1->popularity);
+        self::assertSame($document1->popularity, $document2->popularity);
+
+        $cacheProperty = new \ReflectionProperty(PopularityDataMapper::class, 'popularityCache');
+        $cache = $cacheProperty->getValue($dataMapper);
+        self::assertInstanceOf(\Countable::class, $cache);
+        self::assertCount(1, $cache, 'The popularity must be computed and cached once per product, not once per scope');
+    }
+
+    private function reloadProductByCode(string $code): Product
+    {
+        // Detach the in-memory graph so the lookup hydrates a fresh managed entity from the
+        // database (with generated ids) rather than returning the identity-mapped instance.
+        $this->manager->clear();
+
+        $product = $this->manager->getRepository(Product::class)->findOneBy(['code' => $code]);
+        self::assertInstanceOf(Product::class, $product);
+
+        return $product;
     }
 
     private function createOrder(

--- a/tests/Unit/Indexer/DefaultIndexerTest.php
+++ b/tests/Unit/Indexer/DefaultIndexerTest.php
@@ -139,6 +139,26 @@ final class DefaultIndexerTest extends TestCase
     /**
      * @test
      */
+    public function it_does_not_create_an_add_documents_task_for_an_empty_batch(): void
+    {
+        $logger = new SpyLogger();
+
+        // The single entity is filtered out, so no documents remain to index. createIndexer stubs
+        // addDocuments, but here we assert that a valid-but-empty batch issues no addDocuments task.
+        $indexer = $this->createIndexer($logger, passesFilter: true, violations: new ConstraintViolationList([
+            new ConstraintViolation('invalid', null, [], '', 'name', null),
+        ]));
+
+        $indexer->indexEntities([$this->createEntity()]);
+
+        $summary = $logger->firstOfLevel('info');
+        self::assertNotNull($summary);
+        self::assertSame(0, $summary['context']['indexed']);
+    }
+
+    /**
+     * @test
+     */
     public function it_removes_a_filtered_out_entity_from_the_index(): void
     {
         $index = new Index('products', ProductDocument::class, [Product::class], new Container());
@@ -154,7 +174,8 @@ final class DefaultIndexerTest extends TestCase
         $objectFilter->filter(Argument::cetera())->willReturn(false);
 
         $indexes = $this->prophesize(Indexes::class);
-        $indexes->addDocuments([], 'id')->shouldBeCalled()->willReturn([]);
+        // Nothing to index (the only entity was filtered out), so no addDocuments task is created
+        $indexes->addDocuments(Argument::cetera())->shouldNotBeCalled();
         // The filtered-out entity is removed from the index
         $indexes->deleteDocuments(['42'])->shouldBeCalledOnce()->willReturn([]);
 


### PR DESCRIPTION
## What

Three local fixes to make full reindexing lighter:

1. **`EntityManager::clear()` after each batch.** `IndexEntitiesHandler` loaded 100 full entities (plus associations) per message and never detached them, so a synchronous full reindex accumulated the entire catalog in memory in one process. It now clears the manager at the end of the batch.
2. **Memoized popularity.** Popularity doesn't vary by scope, but `PopularityDataMapper::map()` ran its `COUNT(DISTINCT ...)` query on every invocation — i.e. once per product × scope (~18× per product with 3 channels × 3 locales × 2 currencies). It now memoizes the value per product object in a `WeakMap`, so the query runs once per product. Keying on the object means the cache is bounded and drops entries automatically once a batch's entities are detached by `clear()` and garbage-collected.
3. **No empty-batch task.** `DefaultIndexer` now skips the `addDocuments()` call when there are no documents to index (everything filtered out/dropped), avoiding pointless empty Meilisearch tasks.

## Testing

- `PopularityDataMapperTest::testItMemoizesPopularityAcrossScopes`: mapping the same product for two scopes yields the same value and the memoization cache holds exactly one entry.
- `DefaultIndexerTest::it_does_not_create_an_add_documents_task_for_an_empty_batch`.

Closes #126

---
_Stacked on #159 (#125)._