### PR TITLE
Only run per-facet sub-queries for facets with active selections

### DIFF
--- a/src/Meilisearch/Query/MultiSearchBuilder.php
+++ b/src/Meilisearch/Query/MultiSearchBuilder.php
@@ -72,8 +72,16 @@ final class MultiSearchBuilder implements MultiSearchBuilderInterface
         $searchQueries = [];
 
         foreach ($facets as $facet) {
+            // A dedicated disjunctive sub-query is only needed for facets the user has actively
+            // filtered on — only there must the facet's own filter be excluded to show its full
+            // distribution. Every other facet reads its counts from the main query's
+            // facetDistribution for free, so we skip its sub-query.
+            if (!self::hasActiveSelection($facet, $filters)) {
+                continue;
+            }
+
             /** @var array<string, mixed> $filteredFacets */
-            $filteredFacets = array_filter($filters, static fn ($value) => $value !== $facet->name, \ARRAY_FILTER_USE_KEY);
+            $filteredFacets = array_filter($filters, static fn ($key) => $key !== $facet->name, \ARRAY_FILTER_USE_KEY);
 
             $searchQueries[] = $this->searchQueryBuilder->build(
                 indexName: $index->uid(),
@@ -86,5 +94,28 @@ final class MultiSearchBuilder implements MultiSearchBuilderInterface
         }
 
         return $searchQueries;
+    }
+
+    /**
+     * Whether the request carries a non-empty selection for the given facet.
+     *
+     * @param array<string, mixed> $filters
+     */
+    private static function hasActiveSelection(Facet $facet, array $filters): bool
+    {
+        if (!isset($filters[$facet->name])) {
+            return false;
+        }
+
+        $value = $filters[$facet->name];
+
+        if (is_array($value)) {
+            $value = array_filter($value, static fn ($v): bool => $v !== '' && $v !== null && $v !== []);
+
+            return [] !== $value;
+        }
+
+        // isset() above already guarantees a non-null value here
+        return $value !== '';
     }
 }

--- a/tests/Unit/Meilisearch/Query/MultiSearchBuilderTest.php
+++ b/tests/Unit/Meilisearch/Query/MultiSearchBuilderTest.php
@@ -10,6 +10,7 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Setono\SyliusMeilisearchPlugin\Config\Index;
 use Setono\SyliusMeilisearchPlugin\Document\Attribute\Sortable as SortableAttribute;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Facet;
 use Setono\SyliusMeilisearchPlugin\Document\Metadata\Metadata;
 use Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactoryInterface;
 use Setono\SyliusMeilisearchPlugin\Document\Metadata\Sortable;
@@ -32,7 +33,17 @@ final class MultiSearchBuilderTest extends TestCase
     private function createBuilder(): MultiSearchBuilder
     {
         $searchQueryBuilder = $this->prophesize(SearchQueryBuilderInterface::class);
-        $searchQueryBuilder->build(Argument::cetera())->will(static fn (): SearchQuery => new SearchQuery());
+        $searchQueryBuilder->build(Argument::cetera())->will(static function (array $args): SearchQuery {
+            $query = new SearchQuery();
+            // build(string $indexName, ?string $query, array $facets, array $filter)
+            if (isset($args[2]) && is_array($args[2]) && [] !== $args[2]) {
+                /** @var list<non-empty-string> $facets */
+                $facets = $args[2];
+                $query->setFacets($facets);
+            }
+
+            return $query;
+        });
 
         $filterBuilder = $this->prophesize(FilterBuilderInterface::class);
         $filterBuilder->build(Argument::cetera())->willReturn([]);
@@ -45,6 +56,8 @@ final class MultiSearchBuilderTest extends TestCase
         $metadata = new Metadata(ProductDocument::class);
         $metadata->sortableAttributes['createdAt'] = new Sortable('createdAt');
         $metadata->sortableAttributes['price'] = new Sortable('price', SortableAttribute::ASC);
+        $metadata->facetableAttributes['brand'] = new Facet('brand', 'array');
+        $metadata->facetableAttributes['onSale'] = new Facet('onSale', 'bool');
 
         $metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
         $metadataFactory->getMetadataFor(ProductDocument::class)->willReturn($metadata);
@@ -105,5 +118,46 @@ final class MultiSearchBuilderTest extends TestCase
         self::assertNull($this->buildSort('createdAt'));
         self::assertNull($this->buildSort('createdAt:asc:desc'));
         self::assertNull($this->buildSort(null));
+    }
+
+    /**
+     * @test
+     */
+    public function it_issues_only_the_main_query_when_no_facet_is_selected(): void
+    {
+        $queries = $this->createBuilder()->build($this->createIndex(), new SearchRequest('query'));
+
+        self::assertCount(1, $queries);
+        // The main query still requests every facet, so all facet counts are populated for free
+        self::assertSame(['brand', 'onSale'], $queries[0]->toArray()['facets'] ?? null);
+    }
+
+    /**
+     * @test
+     */
+    public function it_issues_a_sub_query_only_for_the_selected_facet(): void
+    {
+        $queries = $this->createBuilder()->build(
+            $this->createIndex(),
+            new SearchRequest('query', ['brand' => ['brand1']]),
+        );
+
+        // main query + exactly one sub-query, for the selected "brand" facet only
+        self::assertCount(2, $queries);
+        self::assertSame(['brand'], $queries[1]->toArray()['facets'] ?? null);
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_empty_facet_selections(): void
+    {
+        $queries = $this->createBuilder()->build(
+            $this->createIndex(),
+            // present but empty selections must not trigger a sub-query
+            new SearchRequest('query', ['brand' => [''], 'onSale' => '']),
+        );
+
+        self::assertCount(1, $queries);
     }
 }


### PR DESCRIPTION
## What

Every search ran **one extra Meilisearch sub-query per facetable attribute** (each re-running the whole search with all filters except its own, `limit 1`) plus the main query, inside a single `multiSearch`. That's correct disjunctive faceting, but the cost scaled linearly with the number of facets and was paid on every page load, keystroke-search, filter change and pagination click.

A dedicated sub-query is only *needed* for facets the user has **actively filtered on** — only there must the facet's own filter be excluded to show the full distribution. All other facets can read their counts from the main query's `facetDistribution` for free (the main query already requests every facet, and `SearchEngine` already merges sub-query distributions over the main one). So `MultiSearchBuilder::buildFacetQueries()` now emits a sub-query only for facets with a non-empty selection.

Typical result: **N+1 queries → 1** with no filters active, **2–3** with one or two facets selected.

## Testing

- `it_issues_only_the_main_query_when_no_facet_is_selected` (main query still requests every facet).
- `it_issues_a_sub_query_only_for_the_selected_facet` (main + exactly one sub-query, for the selected facet).
- `it_ignores_empty_facet_selections`.
- The functional `SearchTest` (multi-criteria facet + price filtering) still passes, confirming disjunctive behaviour is preserved.

Closes #127

---
_Stacked on #160 (#126)._