### PR TITLE
Improve IndexCommand output: resolved uids, summary, honest --delete warning

### DIFF
--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -13,6 +13,7 @@ use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -82,48 +83,81 @@ final class IndexCommand extends Command
     {
         /** @var list<string> $indexes */
         $indexes = $input->getArgument('indexes');
-        $delete = $input->getOption('delete');
+        $delete = (bool) $input->getOption('delete');
 
         if ($delete) {
-            $output->writeln('<comment>WARNING: The delete option is enabled</comment>');
+            $output->writeln('<comment>WARNING: --delete is enabled — each index is deleted before it is rebuilt, so search returns no results for that index until reindexing completes. A plain reindex (without --delete) upserts in place and avoids this downtime.</comment>');
         }
 
+        $uids = [];
+
         foreach ($indexes as $index) {
-            $output->writeln(sprintf('Index "%s" submitted for indexing', $index));
+            $indexUids = $this->resolveIndexUidsForIndex($index);
+            foreach ($indexUids as $uid) {
+                $uids[$uid] = $uid;
+            }
+
+            $output->writeln(sprintf('Indexing <info>%s</info> → %s', $index, implode(', ', $indexUids)));
 
             $this->commandBus->dispatch(new Index($index, $delete));
         }
+
+        $uids = array_values($uids);
 
         /** @var bool $wait */
         $wait = $input->getOption('wait');
 
         if ($wait) {
-            $this->wait($this->resolveIndexUids($indexes), (int) $input->getOption('wait-timeout'), $output);
+            $this->wait($uids, (int) $input->getOption('wait-timeout'), $output);
+            $this->printSummary($uids, $output);
         }
 
         return 0;
     }
 
     /**
-     * Resolves the concrete Meilisearch index uids (across all scopes) for the given index names,
-     * so --wait only waits on tasks belonging to this run rather than every task on the instance.
-     *
-     * @param list<string> $indexes
+     * Resolves the concrete Meilisearch index uids (across all scopes) for a single index name.
      *
      * @return list<string>
      */
-    private function resolveIndexUids(array $indexes): array
+    private function resolveIndexUidsForIndex(string $index): array
     {
         $uids = [];
 
-        foreach ($indexes as $index) {
-            foreach ($this->indexScopeProvider->getAll($this->indexRegistry->get($index)) as $indexScope) {
-                $uid = $this->indexUidResolver->resolveFromIndexScope($indexScope);
-                $uids[$uid] = $uid;
-            }
+        foreach ($this->indexScopeProvider->getAll($this->indexRegistry->get($index)) as $indexScope) {
+            $uid = $this->indexUidResolver->resolveFromIndexScope($indexScope);
+            $uids[$uid] = $uid;
         }
 
         return array_values($uids);
+    }
+
+    /**
+     * Prints the resulting document count per resolved uid. Only meaningful once the Meilisearch
+     * tasks have finished, which is why it is called after --wait.
+     *
+     * @param list<string> $uids
+     */
+    private function printSummary(array $uids, OutputInterface $output): void
+    {
+        $table = new Table($output);
+        $table->setHeaders(['Index uid', 'Documents']);
+
+        foreach ($uids as $uid) {
+            try {
+                $stats = $this->client->index($uid)->stats();
+                $documents = $stats['numberOfDocuments'] ?? null;
+                $count = is_scalar($documents) ? (string) $documents : '?';
+            } catch (\Throwable) {
+                $count = 'n/a';
+            }
+
+            $table->addRow([$uid, $count]);
+        }
+
+        $output->writeln('');
+        $output->writeln('<info>Index summary</info>');
+        $table->render();
     }
 
     /**

--- a/tests/Unit/Command/IndexCommandTest.php
+++ b/tests/Unit/Command/IndexCommandTest.php
@@ -4,14 +4,31 @@ declare(strict_types=1);
 
 namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Command;
 
+use Meilisearch\Client;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Setono\SyliusMeilisearchPlugin\Command\IndexCommand;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Config\IndexRegistryInterface;
+use Setono\SyliusMeilisearchPlugin\Document\Product as ProductDocument;
+use Setono\SyliusMeilisearchPlugin\Message\Command\Index as IndexMessage;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScopeProviderInterface;
+use Setono\SyliusMeilisearchPlugin\Resolver\IndexUid\IndexUidResolverInterface;
+use Setono\SyliusMeilisearchPlugin\Tests\Application\Entity\Product;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * @covers \Setono\SyliusMeilisearchPlugin\Command\IndexCommand
  */
 final class IndexCommandTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */
@@ -36,5 +53,46 @@ final class IndexCommandTest extends TestCase
 
         self::assertSame('enqueued,processing', $array['statuses']);
         self::assertArrayNotHasKey('indexUids', $array);
+    }
+
+    /**
+     * @test
+     */
+    public function it_prints_the_resolved_uids_and_an_honest_delete_warning(): void
+    {
+        $index = new Index('products', ProductDocument::class, [Product::class], new Container());
+        $indexScope = new IndexScope($index, 'FASHION_WEB', 'en_US', 'USD');
+
+        $commandBus = $this->prophesize(MessageBusInterface::class);
+        $commandBus->dispatch(Argument::type(IndexMessage::class))->willReturn(new Envelope(new \stdClass()));
+
+        $indexRegistry = $this->prophesize(IndexRegistryInterface::class);
+        $indexRegistry->getNames()->willReturn(['products']);
+        $indexRegistry->has('products')->willReturn(true);
+        $indexRegistry->get('products')->willReturn($index);
+
+        $indexScopeProvider = $this->prophesize(IndexScopeProviderInterface::class);
+        $indexScopeProvider->getAll($index)->willReturn([$indexScope]);
+
+        $uidResolver = $this->prophesize(IndexUidResolverInterface::class);
+        $uidResolver->resolveFromIndexScope($indexScope)->willReturn('products__fashion_web__en_us__usd');
+
+        $command = new IndexCommand(
+            $commandBus->reveal(),
+            $indexRegistry->reveal(),
+            $this->prophesize(Client::class)->reveal(),
+            $indexScopeProvider->reveal(),
+            $uidResolver->reveal(),
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['indexes' => ['products'], '--delete' => true]);
+
+        $display = $tester->getDisplay();
+
+        // Names each resolved index uid
+        self::assertStringContainsString('products__fashion_web__en_us__usd', $display);
+        // The --delete warning explains the downtime
+        self::assertStringContainsString('search returns no results', $display);
     }
 }


### PR DESCRIPTION
## What

`setono:sylius-meilisearch:index` printed only `Index "%s" submitted for indexing`. Now:

- **Resolved uids up front.** Each index prints the concrete Meilisearch uids it will write, across all scopes: `Indexing products → products__fashion_web__en_us__usd, …`. In the default (synchronous) setup this also makes clear the command is doing real work, not hanging.
- **Honest `--delete` warning.** Reworded to state the consequence explicitly: the live index is deleted first, so search returns no results for that index until reindexing completes; a plain reindex (without `--delete`) upserts in place and avoids the downtime.
- **Summary after `--wait`.** Once the Meilisearch tasks have finished (which is why it's printed after `--wait`), a table of document count per resolved uid is shown.

The per-batch mapped/filtered/invalid/indexed counts are emitted to the dedicated log channel by the indexer (#128) — those can't be aggregated back into the command process for an async run, so the command's summary reports the resulting document counts instead.

## Testing

- `IndexCommandTest::it_prints_the_resolved_uids_and_an_honest_delete_warning` (via `CommandTester`): output names each resolved uid and the `--delete` warning explains the downtime.
- The existing `createTasksQuery` tests still pass.

Closes #131

---
_Stacked on #162 (#129)._