### PR TITLE
Ship ordered searchable defaults on the built-in Product document

### DIFF
--- a/src/Document/Product.php
+++ b/src/Document/Product.php
@@ -12,7 +12,7 @@ use Setono\SyliusMeilisearchPlugin\Document\Attribute\Sortable;
 
 class Product extends Document implements UrlAwareInterface
 {
-    #[Searchable]
+    #[Searchable(priority: 100)]
     public ?string $name = null;
 
     #[Sortable(direction: Sortable::DESC)]
@@ -33,6 +33,7 @@ class Product extends Document implements UrlAwareInterface
 
     /** @var list<string> */
     #[Facetable]
+    #[Searchable(priority: 50)]
     public array $taxons = [];
 
     public ?string $currency = null;

--- a/tests/Unit/Document/ProductSearchableOrderTest.php
+++ b/tests/Unit/Document/ProductSearchableOrderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Document;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactory;
+use Setono\SyliusMeilisearchPlugin\Document\Product;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Document\Product
+ */
+final class ProductSearchableOrderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * The built-in Product document ships ordered searchable defaults: name ranks above taxons.
+     *
+     * @test
+     */
+    public function it_ships_ordered_searchable_defaults_with_name_first(): void
+    {
+        $factory = new MetadataFactory($this->prophesize(EventDispatcherInterface::class)->reveal());
+
+        $metadata = $factory->getMetadataFor(Product::class);
+
+        self::assertSame(['name', 'taxons'], $metadata->getSearchableAttributeNames());
+    }
+}

--- a/tests/Unit/Provider/Settings/DefaultSettingsProviderTest.php
+++ b/tests/Unit/Provider/Settings/DefaultSettingsProviderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Provider\Settings;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Config\Index;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Metadata;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactoryInterface;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Searchable;
+use Setono\SyliusMeilisearchPlugin\Document\Product as ProductDocument;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\SynonymResolverInterface;
+use Setono\SyliusMeilisearchPlugin\Provider\IndexScope\IndexScope;
+use Setono\SyliusMeilisearchPlugin\Provider\Settings\DefaultSettingsProvider;
+use Setono\SyliusMeilisearchPlugin\Tests\Application\Entity\Product;
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Provider\Settings\DefaultSettingsProvider
+ */
+final class DefaultSettingsProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_emits_an_ordered_searchable_attributes_list(): void
+    {
+        $metadata = new Metadata(ProductDocument::class);
+        // deliberately added in a non-priority order to prove the provider orders them
+        $metadata->searchableAttributes['description'] = new Searchable('description', 10);
+        $metadata->searchableAttributes['name'] = new Searchable('name', 100);
+        $metadata->searchableAttributes['brand'] = new Searchable('brand', 50);
+
+        $metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $metadataFactory->getMetadataFor(ProductDocument::class)->willReturn($metadata);
+
+        $synonymResolver = $this->prophesize(SynonymResolverInterface::class);
+        $synonymResolver->resolve(Argument::type(IndexScope::class))->willReturn([]);
+
+        $provider = new DefaultSettingsProvider($synonymResolver->reveal(), $metadataFactory->reveal());
+
+        $index = new Index('products', ProductDocument::class, [Product::class], new Container());
+        $settings = $provider->getSettings(new IndexScope($index));
+
+        self::assertSame(['name', 'brand', 'description'], $settings->searchableAttributes->jsonSerialize());
+    }
+
+    /**
+     * @test
+     */
+    public function it_falls_back_to_the_wildcard_when_no_attribute_is_searchable(): void
+    {
+        $metadata = new Metadata(ProductDocument::class);
+
+        $metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $metadataFactory->getMetadataFor(ProductDocument::class)->willReturn($metadata);
+
+        $synonymResolver = $this->prophesize(SynonymResolverInterface::class);
+        $synonymResolver->resolve(Argument::type(IndexScope::class))->willReturn([]);
+
+        $provider = new DefaultSettingsProvider($synonymResolver->reveal(), $metadataFactory->reveal());
+
+        $index = new Index('products', ProductDocument::class, [Product::class], new Container());
+        $settings = $provider->getSettings(new IndexScope($index));
+
+        self::assertSame(['*'], $settings->searchableAttributes->jsonSerialize());
+    }
+}


### PR DESCRIPTION
## What

`searchableAttributes` defaults to `['*']`, weighting every field equally. Meilisearch's attribute ranking is ordered, and putting `name` before `description` is the single highest-leverage relevance lever.

The **mechanism** for this is already in place: `#[Searchable(priority:)]` exists, `Metadata::getSearchableAttributeNames()` sorts by priority (desc), and `DefaultSettingsProvider` emits those names as an ordered `searchableAttributes` list — falling back to `['*']` (via `UniqueList::ifEmpty`) only when no attribute is searchable. This mirrors how `#[Facetable(position:)]` already works (#56).

What was missing were sensible **defaults on the built-in `Product` document**, which only marked `name` searchable. Now:
- `name` → `#[Searchable(priority: 100)]`
- `taxons` → `#[Searchable(priority: 50)]`

so name matches outrank taxon matches out of the box. Subclasses can add `brand`/`description` at lower priorities.

## Testing

- `DefaultSettingsProviderTest`: a document with prioritized searchable attributes produces an ordered `searchableAttributes` list (added out of priority order, emitted `name, brand, description`); no searchable attributes → `['*']`.
- `ProductSearchableOrderTest`: the built-in `Product` document's searchable attributes are ordered `['name', 'taxons']`.

Closes #138

---
_Stacked on #163 (#131)._