### PR TITLE
Batch-hydrate search hits, drop stale ones and self-heal the index

### DIFF
--- a/src/Controller/Action/SearchAction.php
+++ b/src/Controller/Action/SearchAction.php
@@ -6,6 +6,8 @@ namespace Setono\SyliusMeilisearchPlugin\Controller\Action;
 
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Setono\Doctrine\ORMTrait;
 use Setono\SyliusMeilisearchPlugin\Engine\SearchEngineInterface;
 use Setono\SyliusMeilisearchPlugin\Engine\SearchRequest;
@@ -14,9 +16,12 @@ use Setono\SyliusMeilisearchPlugin\Event\Search\SearchResponseCreated;
 use Setono\SyliusMeilisearchPlugin\Event\Search\SearchResponseParametersCreated;
 use Setono\SyliusMeilisearchPlugin\Event\Search\SearchResultReceived;
 use Setono\SyliusMeilisearchPlugin\Form\Builder\SearchFormBuilderInterface;
+use Setono\SyliusMeilisearchPlugin\Message\Command\RemoveEntity;
 use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Sylius\Component\Resource\Model\ToggleableInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Twig\Environment;
 
 final class SearchAction
@@ -29,6 +34,8 @@ final class SearchAction
         private readonly SearchFormBuilderInterface $searchFormBuilder,
         private readonly SearchEngineInterface $searchEngine,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly MessageBusInterface $commandBus,
+        private readonly LoggerInterface $logger = new NullLogger(),
     ) {
         $this->managerRegistry = $managerRegistry;
     }
@@ -48,18 +55,7 @@ final class SearchAction
             // todo handle this scenario
         }
 
-        $items = [];
-        /** @var array{entityClass: class-string<IndexableInterface>, entityId: mixed} $hit */
-        foreach ($searchResult->hits as $hit) {
-            $item = $this->getManager($hit['entityClass'])->find($hit['entityClass'], $hit['entityId']);
-
-            // todo if the item doesn't exist in the database, we can in fact end up with an empty $items list
-            if (null === $item) {
-                continue;
-            }
-
-            $items[] = $item;
-        }
+        $items = $this->hydrateHits($searchResult->hits);
 
         $searchResponseParametersCreatedEvent = new SearchResponseParametersCreated('@SetonoSyliusMeilisearchPlugin/search/index.html.twig', [
             'searchResult' => $searchResult,
@@ -79,5 +75,100 @@ final class SearchAction
         $this->eventDispatcher->dispatch(new SearchResponseCreated($request, $response));
 
         return $response;
+    }
+
+    /**
+     * Hydrates the Meilisearch hits into entities: one findBy() per entity class (instead of one
+     * find() per hit), reordered to match Meilisearch's ranking. Hits whose entity is missing from
+     * the database or disabled are dropped and a RemoveEntity is dispatched so the index self-heals.
+     *
+     * @param array<int, array> $hits
+     *
+     * @return list<IndexableInterface>
+     */
+    private function hydrateHits(array $hits): array
+    {
+        // Group hit ids by entity class, preserving Meilisearch's order
+        $idsByClass = [];
+        foreach ($hits as $hit) {
+            $class = $hit['entityClass'] ?? null;
+            if (!is_string($class) || !is_a($class, IndexableInterface::class, true)) {
+                continue;
+            }
+
+            $idsByClass[$class][] = $hit['entityId'] ?? null;
+        }
+
+        // Load each class in a single query, keyed by (string) id
+        $loaded = [];
+        foreach ($idsByClass as $class => $ids) {
+            /** @var list<IndexableInterface> $entities */
+            $entities = $this->getRepository($class)->findBy(['id' => $ids]);
+            foreach ($entities as $entity) {
+                $loaded[$class][(string) $entity->getId()] = $entity;
+            }
+        }
+
+        [$items, $stale] = self::reorderAndFilter($hits, $loaded);
+
+        foreach ($stale as $hit) {
+            try {
+                $this->commandBus->dispatch(new RemoveEntity($hit['entityClass'], $hit['entityId'], $hit['documentIdentifier']));
+            } catch (\Throwable $e) {
+                // Self-healing must never break rendering the search page
+                $this->logger->error('Failed to dispatch RemoveEntity for a stale search hit: {message}', [
+                    'message' => $e->getMessage(),
+                    'entity' => $hit['entityClass'],
+                    'exception' => $e,
+                ]);
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * Reorders the loaded entities to match Meilisearch's hit order and separates out the stale
+     * hits (missing from the database, or disabled) so the caller can self-heal the index.
+     *
+     * @param array<int, array<array-key, mixed>> $hits
+     * @param array<string, array<array-key, IndexableInterface>> $loaded
+     *
+     * @return array{0: list<IndexableInterface>, 1: list<array{entityClass: class-string<IndexableInterface>, entityId: int|string, documentIdentifier: string|null}>}
+     */
+    public static function reorderAndFilter(array $hits, array $loaded): array
+    {
+        $items = [];
+        $stale = [];
+
+        foreach ($hits as $hit) {
+            $class = $hit['entityClass'] ?? null;
+            $id = $hit['entityId'] ?? null;
+
+            if (!is_string($class) || !is_a($class, IndexableInterface::class, true) || (!is_string($id) && !is_int($id))) {
+                continue;
+            }
+
+            $entity = $loaded[$class][(string) $id] ?? null;
+
+            // A hit whose entity was deleted, or that is now disabled, must not be rendered (the
+            // index is stale); dispatch a removal so it heals on the next request instead. The
+            // document is removed by its own Meilisearch primary key ('id'), captured from the hit.
+            if (null === $entity || ($entity instanceof ToggleableInterface && !$entity->isEnabled())) {
+                $documentIdentifier = $hit['id'] ?? null;
+
+                $stale[] = [
+                    'entityClass' => $class,
+                    'entityId' => $id,
+                    'documentIdentifier' => is_scalar($documentIdentifier) ? (string) $documentIdentifier : null,
+                ];
+
+                continue;
+            }
+
+            $items[] = $entity;
+        }
+
+        return [$items, $stale];
     }
 }

--- a/src/Resources/config/services/conditional/search.xml
+++ b/src/Resources/config/services/conditional/search.xml
@@ -13,6 +13,10 @@
             <argument type="service" id="Setono\SyliusMeilisearchPlugin\Form\Builder\SearchFormBuilderInterface"/>
             <argument type="service" id="Setono\SyliusMeilisearchPlugin\Engine\SearchEngineInterface"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="setono_sylius_meilisearch.command_bus"/>
+            <argument type="service" id="logger"/>
+
+            <tag name="monolog.logger" channel="setono_sylius_meilisearch"/>
         </service>
 
         <service id="Setono\SyliusMeilisearchPlugin\Engine\SearchEngine">

--- a/tests/Unit/Controller/Action/SearchActionTest.php
+++ b/tests/Unit/Controller/Action/SearchActionTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Controller\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Controller\Action\SearchAction;
+use Setono\SyliusMeilisearchPlugin\Model\IndexableInterface;
+use Sylius\Component\Resource\Model\ToggleableInterface;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Controller\Action\SearchAction
+ */
+final class SearchActionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private function indexable(): IndexableInterface
+    {
+        return $this->prophesize(IndexableInterface::class)->reveal();
+    }
+
+    private function enabledToggleable(bool $enabled): IndexableInterface
+    {
+        $entity = $this->prophesize(IndexableInterface::class);
+        $entity->willImplement(ToggleableInterface::class);
+        $entity->isEnabled()->willReturn($enabled);
+
+        return $entity->reveal();
+    }
+
+    /**
+     * A Meilisearch hit carries its own primary key ('id', the document identifier) alongside the
+     * entity coordinates.
+     *
+     * @param class-string<IndexableInterface> $class
+     *
+     * @return array{id: string, entityClass: class-string<IndexableInterface>, entityId: int|string}
+     */
+    private function hit(string $class, int|string $id): array
+    {
+        return ['id' => (string) $id, 'entityClass' => $class, 'entityId' => $id];
+    }
+
+    /**
+     * @param class-string<IndexableInterface> $class
+     *
+     * @return array{entityClass: class-string<IndexableInterface>, entityId: int|string, documentIdentifier: string|null}
+     */
+    private function stale(string $class, int|string $id): array
+    {
+        return ['entityClass' => $class, 'entityId' => $id, 'documentIdentifier' => (string) $id];
+    }
+
+    /**
+     * @test
+     */
+    public function it_reorders_loaded_entities_to_match_the_hit_order(): void
+    {
+        $class = IndexableInterface::class;
+        $a = $this->indexable();
+        $b = $this->indexable();
+        $c = $this->indexable();
+
+        // Loaded in a different order than the hits (as findBy would return them)
+        $loaded = [$class => ['2' => $b, '3' => $c, '1' => $a]];
+        $hits = [$this->hit($class, 1), $this->hit($class, 2), $this->hit($class, 3)];
+
+        [$items, $stale] = SearchAction::reorderAndFilter($hits, $loaded);
+
+        self::assertSame([$a, $b, $c], $items);
+        self::assertSame([], $stale);
+    }
+
+    /**
+     * @test
+     */
+    public function it_drops_and_reports_a_hit_whose_entity_is_missing(): void
+    {
+        $class = IndexableInterface::class;
+        $a = $this->indexable();
+
+        $loaded = [$class => ['1' => $a]];
+        $hits = [$this->hit($class, 1), $this->hit($class, 2)];
+
+        [$items, $stale] = SearchAction::reorderAndFilter($hits, $loaded);
+
+        self::assertSame([$a], $items);
+        self::assertSame([$this->stale($class, 2)], $stale);
+    }
+
+    /**
+     * @test
+     */
+    public function it_drops_and_reports_a_disabled_entity(): void
+    {
+        $class = IndexableInterface::class;
+        $enabled = $this->enabledToggleable(true);
+        $disabled = $this->enabledToggleable(false);
+
+        $loaded = [$class => ['1' => $enabled, '2' => $disabled]];
+        $hits = [$this->hit($class, 1), $this->hit($class, 2)];
+
+        [$items, $stale] = SearchAction::reorderAndFilter($hits, $loaded);
+
+        self::assertSame([$enabled], $items);
+        self::assertSame([$this->stale($class, 2)], $stale);
+    }
+}


### PR DESCRIPTION
## What

`SearchAction` re-hydrated every Meilisearch hit from the database **one `find()` at a time** — with the default `hits_per_page` of 60, up to 60 extra queries per search page, partly negating Meilisearch's speed. On top of that a hit whose entity no longer existed was silently dropped (so the "N results" count and the rendered cards could disagree, and the page could even render empty while claiming results), and `find()` didn't re-check `enabled`, so a product disabled after its last indexing was still displayed.

- **Batch hydration:** hit ids are grouped by `entityClass` and each group is loaded with a single `findBy(['id' => $ids])`, then reordered to match Meilisearch's ranking. 60 queries become one per entity class.
- **Drop stale hits + self-heal:** a hit whose entity is missing from the database, or is disabled (`ToggleableInterface`), is not rendered and a `RemoveEntity` is dispatched for it so the index heals on the next request. The dispatch is failure-safe — an error is logged, never breaks rendering.
- The reorder/drop logic lives in the pure static `reorderAndFilter()` for straightforward unit testing.

## Testing

- `SearchActionTest`: entities are reordered to match the hit order; a hit whose entity is missing is dropped and reported stale; a disabled entity is dropped and reported stale.
- The functional `SearchSortingTest`/`SearchPaginationTest` (which render the search page) still pass; `lint:container` is clean.

Closes #120

---
_Stacked on #164 (#138)._