### PR TITLE
Fix i18n gaps on the search page

### DIFF
--- a/src/Form/Builder/CheckboxFilterFormBuilder.php
+++ b/src/Form/Builder/CheckboxFilterFormBuilder.php
@@ -8,14 +8,20 @@ use Setono\SyliusMeilisearchPlugin\Document\Metadata\Facet;
 use Setono\SyliusMeilisearchPlugin\Engine\FacetValues;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
-use function Symfony\Component\String\u;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class CheckboxFilterFormBuilder implements FilterFormBuilderInterface
 {
+    use FacetLabelTrait;
+
+    public function __construct(private readonly TranslatorInterface $translator)
+    {
+    }
+
     public function build(FormBuilderInterface $builder, Facet $facet, FacetValues $values): void
     {
         $builder->add($facet->name, CheckboxType::class, [
-            'label' => sprintf('setono_sylius_meilisearch.form.search.facet.%s', u($facet->name)->snake()),
+            'label' => $this->facetLabel($this->translator, $facet),
             'label_translation_parameters' => [
                 '%count%' => $values['true'],
             ],

--- a/src/Form/Builder/ChoiceFilterFormBuilder.php
+++ b/src/Form/Builder/ChoiceFilterFormBuilder.php
@@ -10,17 +10,21 @@ use Setono\SyliusMeilisearchPlugin\Engine\FacetValues;
 use Setono\SyliusMeilisearchPlugin\Form\Builder\Sorter\FilterValuesSorterInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
-use function Symfony\Component\String\u;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Webmozart\Assert\Assert;
 
 final class ChoiceFilterFormBuilder implements FilterFormBuilderInterface
 {
+    use FacetLabelTrait;
+
     /**
      * @param ContainerInterface $sorterLocator A service locator of tagged
      *   FilterValuesSorterInterface services, keyed by service id
      */
-    public function __construct(private readonly ContainerInterface $sorterLocator)
-    {
+    public function __construct(
+        private readonly ContainerInterface $sorterLocator,
+        private readonly TranslatorInterface $translator,
+    ) {
     }
 
     public function build(FormBuilderInterface $builder, Facet $facet, FacetValues $values): void
@@ -32,7 +36,7 @@ final class ChoiceFilterFormBuilder implements FilterFormBuilderInterface
         }
 
         $builder->add($facet->name, ChoiceType::class, [
-            'label' => sprintf('setono_sylius_meilisearch.form.search.facet.%s', u($facet->name)->snake()),
+            'label' => $this->facetLabel($this->translator, $facet),
             'choices' => $choices,
             'choice_label' => fn (string $value) => sprintf('%s (%d)', $value, $values->getValueCount($value)),
             'expanded' => true,

--- a/src/Form/Builder/FacetLabelTrait.php
+++ b/src/Form/Builder/FacetLabelTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Form\Builder;
+
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Facet;
+use function Symfony\Component\String\u;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+trait FacetLabelTrait
+{
+    /**
+     * Resolves the label for a facet: the translation key when the catalogue defines it (so
+     * projects can override it), otherwise a humanized version of the facet name so that facets
+     * without a shipped translation (e.g. "brand") don't render their raw translation key.
+     */
+    private function facetLabel(TranslatorInterface $translator, Facet $facet): string
+    {
+        $name = u($facet->name)->snake()->toString();
+        $key = sprintf('setono_sylius_meilisearch.form.search.facet.%s', $name);
+
+        // When the translator returns the key unchanged there is no translation for it, so fall
+        // back to a humanized facet name rather than rendering the raw key.
+        if ($translator->trans($key) !== $key) {
+            return $key;
+        }
+
+        return ucfirst(str_replace('_', ' ', $name));
+    }
+}

--- a/src/Form/Builder/RangeFilterFormBuilder.php
+++ b/src/Form/Builder/RangeFilterFormBuilder.php
@@ -8,14 +8,20 @@ use Setono\SyliusMeilisearchPlugin\Document\Metadata\Facet;
 use Setono\SyliusMeilisearchPlugin\Engine\FacetValues;
 use Setono\SyliusMeilisearchPlugin\Form\Type\RangeType;
 use Symfony\Component\Form\FormBuilderInterface;
-use function Symfony\Component\String\u;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class RangeFilterFormBuilder implements FilterFormBuilderInterface
 {
+    use FacetLabelTrait;
+
+    public function __construct(private readonly TranslatorInterface $translator)
+    {
+    }
+
     public function build(FormBuilderInterface $builder, Facet $facet, FacetValues $values): void
     {
         $builder->add($facet->name, RangeType::class, [
-            'label' => sprintf('setono_sylius_meilisearch.form.search.facet.%s', u($facet->name)->snake()),
+            'label' => $this->facetLabel($this->translator, $facet),
             'required' => false,
             'block_prefix' => 'setono_sylius_meilisearch_facet_range',
             'priority' => -1 * $facet->position,

--- a/src/Form/Type/RangeType.php
+++ b/src/Form/Type/RangeType.php
@@ -15,11 +15,11 @@ final class RangeType extends AbstractType
     {
         $builder
             ->add('min', NumberType::class, [
-                'label' => 'Min',
+                'label' => 'setono_sylius_meilisearch.form.search.range.min',
                 'empty_data' => $options['min'] ?? null,
             ])
             ->add('max', NumberType::class, [
-                'label' => 'Max',
+                'label' => 'setono_sylius_meilisearch.form.search.range.max',
                 'empty_data' => $options['max'] ?? null,
             ])
         ;

--- a/src/Resources/config/services/form.xml
+++ b/src/Resources/config/services/form.xml
@@ -14,11 +14,14 @@
         <service id="Setono\SyliusMeilisearchPlugin\Form\Builder\CompositeFilterFormBuilder"/>
 
         <service id="Setono\SyliusMeilisearchPlugin\Form\Builder\CheckboxFilterFormBuilder">
+            <argument type="service" id="translator"/>
+
             <tag name="setono_sylius_meilisearch.filter_form_builder" priority="100"/>
         </service>
 
         <service id="Setono\SyliusMeilisearchPlugin\Form\Builder\ChoiceFilterFormBuilder">
             <argument type="tagged_locator" tag="setono_sylius_meilisearch.filter_values_sorter"/>
+            <argument type="service" id="translator"/>
 
             <tag name="setono_sylius_meilisearch.filter_form_builder" priority="90"/>
         </service>
@@ -29,6 +32,8 @@
         </service>
 
         <service id="Setono\SyliusMeilisearchPlugin\Form\Builder\RangeFilterFormBuilder">
+            <argument type="service" id="translator"/>
+
             <tag name="setono_sylius_meilisearch.filter_form_builder" priority="80"/>
         </service>
 

--- a/src/Resources/translations/messages.da.yaml
+++ b/src/Resources/translations/messages.da.yaml
@@ -7,10 +7,17 @@ setono_sylius_meilisearch:
                 price: Price
                 size: Size
                 taxons: Category
+            no_results:
+                body: 'Prøv at søge efter noget andet'
+                header: 'Ingen resultater fundet'
             pagination:
                 next: Next
                 previous: Previous
             q_placeholder: Search...
+            range:
+                max: 'Maks'
+                min: 'Min'
+            results_count: '{0}%count% resultater|{1}%count% resultat|]1,Inf[ %count% resultater'
             sorting:
                 createdAt:
                     asc: "Oldest"

--- a/src/Resources/translations/messages.de.yaml
+++ b/src/Resources/translations/messages.de.yaml
@@ -7,10 +7,17 @@ setono_sylius_meilisearch:
                 price: Price
                 size: Size
                 taxons: Category
+            no_results:
+                body: 'Versuchen Sie, nach etwas anderem zu suchen'
+                header: 'Keine Ergebnisse gefunden'
             pagination:
                 next: Next
                 previous: Previous
             q_placeholder: Search...
+            range:
+                max: 'Max'
+                min: 'Min'
+            results_count: '{0}%count% Ergebnisse|{1}%count% Ergebnis|]1,Inf[ %count% Ergebnisse'
             sorting:
                 createdAt:
                     asc: "Oldest"

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -7,10 +7,17 @@ setono_sylius_meilisearch:
                 price: Price
                 size: Size
                 taxons: Category
+            no_results:
+                body: 'Try to search for something else'
+                header: 'No results found'
             pagination:
                 next: Next
                 previous: Previous
             q_placeholder: Search...
+            range:
+                max: 'Max'
+                min: 'Min'
+            results_count: '{0}%count% results|{1}%count% result|]1,Inf[ %count% results'
             sorting:
                 createdAt:
                     asc: "Oldest"

--- a/src/Resources/translations/messages.es.yaml
+++ b/src/Resources/translations/messages.es.yaml
@@ -7,10 +7,17 @@ setono_sylius_meilisearch:
                 price: Price
                 size: Size
                 taxons: Category
+            no_results:
+                body: 'Intenta buscar otra cosa'
+                header: 'No se encontraron resultados'
             pagination:
                 next: Next
                 previous: Previous
             q_placeholder: Search...
+            range:
+                max: 'Máx'
+                min: 'Mín'
+            results_count: '{0}%count% resultados|{1}%count% resultado|]1,Inf[ %count% resultados'
             sorting:
                 createdAt:
                     asc: "Oldest"

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -7,10 +7,17 @@ setono_sylius_meilisearch:
                 price: Price
                 size: Size
                 taxons: Category
+            no_results:
+                body: 'Essayez de rechercher autre chose'
+                header: 'Aucun résultat trouvé'
             pagination:
                 next: Next
                 previous: Previous
             q_placeholder: Search...
+            range:
+                max: 'Max'
+                min: 'Min'
+            results_count: '{0}%count% résultats|{1}%count% résultat|]1,Inf[ %count% résultats'
             sorting:
                 createdAt:
                     asc: "Oldest"

--- a/src/Resources/translations/messages.it.yaml
+++ b/src/Resources/translations/messages.it.yaml
@@ -7,10 +7,17 @@ setono_sylius_meilisearch:
                 price: Price
                 size: Size
                 taxons: Category
+            no_results:
+                body: 'Prova a cercare qualcos''altro'
+                header: 'Nessun risultato trovato'
             pagination:
                 next: Next
                 previous: Previous
             q_placeholder: Search...
+            range:
+                max: 'Max'
+                min: 'Min'
+            results_count: '{0}%count% risultati|{1}%count% risultato|]1,Inf[ %count% risultati'
             sorting:
                 createdAt:
                     asc: "Oldest"

--- a/src/Resources/translations/messages.lt.yaml
+++ b/src/Resources/translations/messages.lt.yaml
@@ -7,10 +7,17 @@ setono_sylius_meilisearch:
                 price: Price
                 size: Size
                 taxons: Category
+            no_results:
+                body: 'Pabandykite ieškoti ko nors kito'
+                header: 'Rezultatų nerasta'
             pagination:
                 next: Next
                 previous: Previous
             q_placeholder: Search...
+            range:
+                max: 'Maks'
+                min: 'Min'
+            results_count: '{0}%count% rezultatai|{1}%count% rezultatas|]1,Inf[ %count% rezultatai'
             sorting:
                 createdAt:
                     asc: "Oldest"

--- a/src/Resources/translations/messages.nl.yaml
+++ b/src/Resources/translations/messages.nl.yaml
@@ -7,10 +7,17 @@ setono_sylius_meilisearch:
                 price: Price
                 size: Size
                 taxons: Category
+            no_results:
+                body: 'Probeer iets anders te zoeken'
+                header: 'Geen resultaten gevonden'
             pagination:
                 next: Next
                 previous: Previous
             q_placeholder: Search...
+            range:
+                max: 'Max'
+                min: 'Min'
+            results_count: '{0}%count% resultaten|{1}%count% resultaat|]1,Inf[ %count% resultaten'
             sorting:
                 createdAt:
                     asc: "Oldest"

--- a/src/Resources/translations/messages.no.yaml
+++ b/src/Resources/translations/messages.no.yaml
@@ -7,10 +7,17 @@ setono_sylius_meilisearch:
                 price: Price
                 size: Size
                 taxons: Category
+            no_results:
+                body: 'Prøv å søke etter noe annet'
+                header: 'Ingen resultater funnet'
             pagination:
                 next: Next
                 previous: Previous
             q_placeholder: Search...
+            range:
+                max: 'Maks'
+                min: 'Min'
+            results_count: '{0}%count% resultater|{1}%count% resultat|]1,Inf[ %count% resultater'
             sorting:
                 createdAt:
                     asc: "Oldest"

--- a/src/Resources/translations/messages.pl.yaml
+++ b/src/Resources/translations/messages.pl.yaml
@@ -7,10 +7,17 @@ setono_sylius_meilisearch:
                 price: Price
                 size: Size
                 taxons: Category
+            no_results:
+                body: 'Spróbuj wyszukać coś innego'
+                header: 'Nie znaleziono wyników'
             pagination:
                 next: Next
                 previous: Previous
             q_placeholder: Search...
+            range:
+                max: 'Maks'
+                min: 'Min'
+            results_count: '{0}%count% wyniki|{1}%count% wynik|]1,Inf[ %count% wyniki'
             sorting:
                 createdAt:
                     asc: "Oldest"

--- a/src/Resources/translations/messages.ro.yaml
+++ b/src/Resources/translations/messages.ro.yaml
@@ -7,10 +7,17 @@ setono_sylius_meilisearch:
                 price: Price
                 size: Size
                 taxons: Category
+            no_results:
+                body: 'Încearcă să cauți altceva'
+                header: 'Niciun rezultat găsit'
             pagination:
                 next: Next
                 previous: Previous
             q_placeholder: Search...
+            range:
+                max: 'Max'
+                min: 'Min'
+            results_count: '{0}%count% rezultate|{1}%count% rezultat|]1,Inf[ %count% rezultate'
             sorting:
                 createdAt:
                     asc: "Oldest"

--- a/src/Resources/translations/messages.sv.yaml
+++ b/src/Resources/translations/messages.sv.yaml
@@ -7,10 +7,17 @@ setono_sylius_meilisearch:
                 price: Price
                 size: Size
                 taxons: Category
+            no_results:
+                body: 'Försök att söka efter något annat'
+                header: 'Inga resultat hittades'
             pagination:
                 next: Next
                 previous: Previous
             q_placeholder: Search...
+            range:
+                max: 'Max'
+                min: 'Min'
+            results_count: '{0}%count% resultat|{1}%count% resultat|]1,Inf[ %count% resultat'
             sorting:
                 createdAt:
                     asc: "Oldest"

--- a/src/Resources/views/search/_hits_count.html.twig
+++ b/src/Resources/views/search/_hits_count.html.twig
@@ -1,2 +1,2 @@
 {# @var searchResult \Setono\SyliusMeilisearchPlugin\Engine\SearchResult #}
-{{ searchResult.totalHits }} results
+{{ 'setono_sylius_meilisearch.form.search.results_count'|trans({'%count%': searchResult.totalHits}) }}

--- a/src/Resources/views/search/_no_results.html.twig
+++ b/src/Resources/views/search/_no_results.html.twig
@@ -1,6 +1,6 @@
 <div class="ui message" id="search-form">
     <div class="header">
-        No results found
+        {{ 'setono_sylius_meilisearch.form.search.no_results.header'|trans }}
     </div>
-    <p>Try to search for something else</p>
+    <p>{{ 'setono_sylius_meilisearch.form.search.no_results.body'|trans }}</p>
 </div>

--- a/tests/Application/e2e/search.spec.ts
+++ b/tests/Application/e2e/search.spec.ts
@@ -49,7 +49,7 @@ test.describe('shop search page', () => {
         // Checking the box auto-submits (there is no submit button in the form)
         await page.locator('.ssm-filters input[name="f[brand][]"][value="Celsius Small"]').check();
         await expect(page).toHaveURL(/f%5Bbrand%5D%5B%5D=Celsius/);
-        await expect(page.getByText('1 results')).toBeVisible();
+        await expect(page.getByText('1 result', { exact: true })).toBeVisible();
         await expect(names(page)).toHaveCount(1);
     });
 
@@ -119,7 +119,7 @@ test.describe('shop search page — history & resilience', () => {
         await expect(names(page)).toHaveCount(3);
         await page.locator('.ssm-filters input[name="f[brand][]"][value="Celsius Small"]').check();
         await expect(page).toHaveURL(/f%5Bbrand%5D%5B%5D=Celsius/);
-        await expect(page.getByText('1 results')).toBeVisible();
+        await expect(page.getByText('1 result', { exact: true })).toBeVisible();
     });
 
     test('submits a typed range filter only once on blur', async ({ page }) => {

--- a/tests/Functional/Translation/ResultsCountPluralizationTest.php
+++ b/tests/Functional/Translation/ResultsCountPluralizationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Functional\Translation;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ResultsCountPluralizationTest extends KernelTestCase
+{
+    /**
+     * @test
+     */
+    public function it_pluralizes_the_results_count(): void
+    {
+        self::bootKernel(['environment' => 'test', 'debug' => true]);
+
+        /** @var TranslatorInterface $translator */
+        $translator = self::getContainer()->get('translator');
+
+        $key = 'setono_sylius_meilisearch.form.search.results_count';
+
+        self::assertSame('0 results', $translator->trans($key, ['%count%' => 0], null, 'en'));
+        self::assertSame('1 result', $translator->trans($key, ['%count%' => 1], null, 'en'));
+        self::assertSame('8 results', $translator->trans($key, ['%count%' => 8], null, 'en'));
+    }
+}

--- a/tests/Unit/Form/Builder/ChoiceFilterFormBuilderTest.php
+++ b/tests/Unit/Form/Builder/ChoiceFilterFormBuilderTest.php
@@ -14,6 +14,7 @@ use Setono\SyliusMeilisearchPlugin\Form\Builder\Sorter\FilterValuesSorterInterfa
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * A reversing sorter referenced by its FQCN (not registered as a service) to exercise
@@ -39,7 +40,7 @@ final class ChoiceFilterFormBuilderTest extends TestCase
      */
     private function buildChoices(Container $locator, ?string $sorter): array
     {
-        $builder = new ChoiceFilterFormBuilder($locator);
+        $builder = new ChoiceFilterFormBuilder($locator, $this->prophesize(TranslatorInterface::class)->reveal());
         $facet = new Facet('brand', 'array', 0, $sorter);
         $facetValues = new FacetValues('brand', ['a' => 1, 'b' => 1, 'c' => 1]);
 

--- a/tests/Unit/Form/Builder/FacetLabelTraitTest.php
+++ b/tests/Unit/Form/Builder/FacetLabelTraitTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Form\Builder;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Facet;
+use Setono\SyliusMeilisearchPlugin\Form\Builder\FacetLabelTrait;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\Translator;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class FacetLabelUser
+{
+    use FacetLabelTrait;
+
+    public function label(TranslatorInterface $translator, Facet $facet): string
+    {
+        return $this->facetLabel($translator, $facet);
+    }
+}
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Form\Builder\FacetLabelTrait
+ */
+final class FacetLabelTraitTest extends TestCase
+{
+    private function translator(): Translator
+    {
+        $translator = new Translator('en');
+        $translator->addLoader('array', new ArrayLoader());
+        $translator->addResource('array', [
+            'setono_sylius_meilisearch.form.search.facet.color' => 'Color',
+        ], 'en');
+
+        return $translator;
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_the_translation_key_when_the_catalogue_defines_it(): void
+    {
+        $user = new FacetLabelUser();
+
+        self::assertSame(
+            'setono_sylius_meilisearch.form.search.facet.color',
+            $user->label($this->translator(), new Facet('color', 'array')),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_humanizes_the_facet_name_when_no_translation_exists(): void
+    {
+        $user = new FacetLabelUser();
+
+        self::assertSame('Brand', $user->label($this->translator(), new Facet('brand', 'array')));
+    }
+}


### PR DESCRIPTION
## What

Several shopper-visible strings on the search page didn't localize:

1. **Facet headings fell back to the raw translation key.** Labels are built as `setono_sylius_meilisearch.form.search.facet.<name>`, but only `color`, `on_sale`, `price`, `size`, `taxons` ship — any other facet (e.g. `brand`, which the e2e suite uses) rendered the literal key. Now, when the catalogue doesn't define the key, the label falls back to a humanized facet name (`Brand`); the key lookup is kept so projects can still override. (`FacetLabelTrait`, used by the checkbox/choice/range filter builders.)
2. **Hardcoded English** — "No results found" / "Try to search for something else" (`_no_results.html.twig`) and the `Min` / `Max` range labels (`RangeType`) are now translation keys.
3. **No pluralization** — `{{ totalHits }} results` rendered "1 results". The hits count now uses a pluralized message so 1 hit renders "1 result".

All new keys (`no_results.*`, `range.*`, `results_count`) are added to the 12 locales, sorted alphabetically, and the `"1 results"` e2e assertion is updated to `"1 result"`.

## Testing

- `FacetLabelTraitTest`: a defined key is used as-is; an undefined facet name is humanized (`brand` → `Brand`).
- `ResultsCountPluralizationTest` (Functional): `results_count` renders `0 results` / `1 result` / `8 results`.
- `lint:yaml` passes on all 12 translation files; the sorting/choice/checkbox functional tests still pass.

Closes #134

---
_Stacked on #165 (#120)._