### PR TITLE
Add a submit button so the search form works without JavaScript

### DIFF
--- a/src/Resources/public/js/search.js
+++ b/src/Resources/public/js/search.js
@@ -193,6 +193,15 @@ class SearchManager {
 
         this.#form = form;
 
+        // JavaScript is available, so changing a filter/sort/page auto-submits. Hide the
+        // fallback submit button, which only exists so the form works without JavaScript.
+        // Set display directly as well: the button carries Semantic UI's `.ui.button`
+        // classes, whose `display` rule outweighs the `[hidden]` attribute on its own.
+        this.#form.querySelectorAll('.ssm-apply-filters').forEach((el) => {
+            el.hidden = true;
+            el.style.display = 'none';
+        });
+
         this.#form.addEventListener('input', (event) => {
             const field = event.target;
 

--- a/src/Resources/translations/messages.da.yaml
+++ b/src/Resources/translations/messages.da.yaml
@@ -1,6 +1,7 @@
 setono_sylius_meilisearch:
     form:
         search:
+            apply_filters: 'Anvend filtre'
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.de.yaml
+++ b/src/Resources/translations/messages.de.yaml
@@ -1,6 +1,7 @@
 setono_sylius_meilisearch:
     form:
         search:
+            apply_filters: 'Filter anwenden'
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -1,6 +1,7 @@
 setono_sylius_meilisearch:
     form:
         search:
+            apply_filters: 'Apply filters'
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.es.yaml
+++ b/src/Resources/translations/messages.es.yaml
@@ -1,6 +1,7 @@
 setono_sylius_meilisearch:
     form:
         search:
+            apply_filters: 'Aplicar filtros'
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -1,6 +1,7 @@
 setono_sylius_meilisearch:
     form:
         search:
+            apply_filters: 'Appliquer les filtres'
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.it.yaml
+++ b/src/Resources/translations/messages.it.yaml
@@ -1,6 +1,7 @@
 setono_sylius_meilisearch:
     form:
         search:
+            apply_filters: 'Applica filtri'
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.lt.yaml
+++ b/src/Resources/translations/messages.lt.yaml
@@ -1,6 +1,7 @@
 setono_sylius_meilisearch:
     form:
         search:
+            apply_filters: 'Taikyti filtrus'
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.nl.yaml
+++ b/src/Resources/translations/messages.nl.yaml
@@ -1,6 +1,7 @@
 setono_sylius_meilisearch:
     form:
         search:
+            apply_filters: 'Filters toepassen'
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.no.yaml
+++ b/src/Resources/translations/messages.no.yaml
@@ -1,6 +1,7 @@
 setono_sylius_meilisearch:
     form:
         search:
+            apply_filters: 'Bruk filtre'
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.pl.yaml
+++ b/src/Resources/translations/messages.pl.yaml
@@ -1,6 +1,7 @@
 setono_sylius_meilisearch:
     form:
         search:
+            apply_filters: 'Zastosuj filtry'
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.ro.yaml
+++ b/src/Resources/translations/messages.ro.yaml
@@ -1,6 +1,7 @@
 setono_sylius_meilisearch:
     form:
         search:
+            apply_filters: 'Aplică filtrele'
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/translations/messages.sv.yaml
+++ b/src/Resources/translations/messages.sv.yaml
@@ -1,6 +1,7 @@
 setono_sylius_meilisearch:
     form:
         search:
+            apply_filters: 'Använd filter'
             facet:
                 color: Color
                 on_sale: On sale (%count%)

--- a/src/Resources/views/search/_results.html.twig
+++ b/src/Resources/views/search/_results.html.twig
@@ -4,6 +4,12 @@
     <div class="ui stackable grid">
         <div class="four wide column">
             {{ include('@SetonoSyliusMeilisearchPlugin/search/_filters.html.twig') }}
+
+            {# Fallback submit button so filters/sorting/pagination work without JavaScript.
+               search.js hides it on init (JS then auto-submits on change). #}
+            <button type="submit" class="ui primary fluid button ssm-apply-filters">
+                {{ 'setono_sylius_meilisearch.form.search.apply_filters'|trans }}
+            </button>
         </div>
         <div class="twelve wide column">
             <div class="ui grid">

--- a/tests/Application/e2e/search.spec.ts
+++ b/tests/Application/e2e/search.spec.ts
@@ -46,11 +46,31 @@ test.describe('shop search page', () => {
     test('filters by a brand facet', async ({ page }) => {
         await page.goto('/en_US/search?q=jeans');
 
-        // Checking the box auto-submits (there is no submit button in the form)
+        // Checking the box auto-submits (with JS the fallback submit button is hidden)
+        await expect(page.locator('.ssm-apply-filters')).toBeHidden();
         await page.locator('.ssm-filters input[name="f[brand][]"][value="Celsius Small"]').check();
         await expect(page).toHaveURL(/f%5Bbrand%5D%5B%5D=Celsius/);
         await expect(page.getByText('1 result', { exact: true })).toBeVisible();
         await expect(names(page)).toHaveCount(1);
+    });
+
+    test.describe('without javascript', () => {
+        test.use({ javaScriptEnabled: false });
+
+        test('filters via the fallback submit button', async ({ page }) => {
+            await page.goto('/en_US/search?q=jeans');
+
+            // Without JS the fallback submit button is visible and the form is a plain GET form
+            const applyButton = page.locator('.ssm-apply-filters');
+            await expect(applyButton).toBeVisible();
+
+            await page.locator('.ssm-filters input[name="f[brand][]"][value="Celsius Small"]').check();
+            await applyButton.click();
+
+            await expect(page).toHaveURL(/f%5Bbrand%5D%5B%5D=Celsius/);
+            await expect(page.getByText('1 result', { exact: true })).toBeVisible();
+            await expect(names(page)).toHaveCount(1);
+        });
     });
 
     test('filters by a price range', async ({ page }) => {


### PR DESCRIPTION
## What

The search results form (facets + sorting + pagination) rendered `form_start … form_end` with **no submit button anywhere** — all submission was done by the JavaScript auto-submit in `search.js`. With JavaScript disabled, blocked, or failed to load, a shopper could run the initial query from the URL but couldn't apply a filter, change sorting, or paginate.

Add a real **"Apply filters"** submit button to `_results.html.twig`, visible by default (so the plain GET form works everywhere) and hidden by `search.js` on init (so the enhanced auto-submit behaviour is unchanged when JS is available). Hiding it in JS — rather than via `<noscript>` — also covers failed/blocked JS.

The `apply_filters` key is translated into all 12 locales.

## Testing

- e2e `filters by a brand facet`: with JS enabled the fallback button is hidden and checking a facet auto-submits.
- e2e `without javascript` (`javaScriptEnabled: false`): the button is visible; checking a facet and pressing it filters the results.
- The functional search-page tests still pass (template renders with the button + translation key).

Closes #122

---
_Stacked on #166 (#134)._