### PR TITLE
Replace radio-based pagination with accessible anchor links

### DIFF
--- a/src/Form/Builder/SearchFormBuilder.php
+++ b/src/Form/Builder/SearchFormBuilder.php
@@ -8,9 +8,7 @@ use Setono\SyliusMeilisearchPlugin\Config\Index;
 use Setono\SyliusMeilisearchPlugin\Document\Metadata\MetadataFactoryInterface;
 use Setono\SyliusMeilisearchPlugin\Engine\SearchRequest;
 use Setono\SyliusMeilisearchPlugin\Engine\SearchResult;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 
@@ -59,33 +57,9 @@ final class SearchFormBuilder implements SearchFormBuilderInterface
 
         $this->sortingFormBuilder->build($searchFormBuilder, $metadata);
 
-        $this->buildPagination($searchResult, $searchFormBuilder);
+        // Pagination is rendered as accessible anchor links (see search/_pagination.html.twig),
+        // not as a form field. The `p` query parameter is read straight from the request.
 
         return $searchFormBuilder->getForm();
-    }
-
-    private function buildPagination(SearchResult $searchResult, FormBuilderInterface $builder): void
-    {
-        $choices = [];
-
-        // current is a special choice that we need to keep the page query parameter in the url on form submission
-        $choices['__current'] = $searchResult->page;
-
-        if ($searchResult->page > 1) {
-            $choices['setono_sylius_meilisearch.form.search.pagination.previous'] = $searchResult->page - 1;
-        }
-
-        if ($searchResult->page < $searchResult->totalPages) {
-            $choices['setono_sylius_meilisearch.form.search.pagination.next'] = $searchResult->page + 1;
-        }
-
-        $builder->add('p', ChoiceType::class, [
-            'choices' => $choices,
-            'choice_attr' => fn (string $page) => ['style' => 'display: none'], // we only want to display the labels
-            'required' => false,
-            'expanded' => true,
-            'placeholder' => false,
-            'block_prefix' => 'setono_sylius_meilisearch_page_choice',
-        ]);
     }
 }

--- a/src/Resources/public/js/search.js
+++ b/src/Resources/public/js/search.js
@@ -215,13 +215,35 @@ class SearchManager {
         this.#form.addEventListener('search:filter-changed', (event) => this.#options.onFilterChange(event.target));
         this.#form.addEventListener('search:page-changed', (event) => this.#options.onPageChange(event.target));
         this.#form.addEventListener('search:sort-changed', (event) => this.#options.onSortChange(event.target));
+
+        // Pagination is a set of anchor links (accessible + crawlable). Intercept plain
+        // left-clicks and navigate via the background search instead of a full page load;
+        // modified clicks (new tab, etc.) fall through to normal navigation.
+        this.#form.addEventListener('click', (event) => {
+            const link = event.target instanceof Element ? event.target.closest('.ssm-pagination a') : null;
+            if (link === null || !this.#form.contains(link)) {
+                return;
+            }
+            if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                return;
+            }
+
+            event.preventDefault();
+
+            // Scroll the new results into view once swapped, as with the old page control.
+            document.addEventListener('search:content-updated', (updated) => {
+                updated.detail.content.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }, { once: true });
+
+            this.#submitForm(link.href);
+        });
         this.#form.addEventListener('submit', (event) => {
             event.preventDefault();
             this.#options.onSubmit();
         });
     }
 
-    async #submitForm() {
+    async #submitForm(targetUrl = null) {
         // Nothing to submit on the "no results" page.
         if (this.#form === null) {
             return;
@@ -233,8 +255,8 @@ class SearchManager {
         const controller = new AbortController();
         this.#abortController = controller;
 
-        // Build the URL up front so the catch block can reuse it for the fallback.
-        const url = this.#buildUrl();
+        // Pagination links pass their own URL; the form controls build the URL from form state.
+        const url = targetUrl ?? this.#buildUrl();
         let navigating = false;
 
         this.#options.loader.show(this.#options.loader.selector);

--- a/src/Resources/translations/messages.da.yaml
+++ b/src/Resources/translations/messages.da.yaml
@@ -11,6 +11,7 @@ setono_sylius_meilisearch:
                 body: 'Prøv at søge efter noget andet'
                 header: 'Ingen resultater fundet'
             pagination:
+                label: 'Paginering'
                 next: Next
                 previous: Previous
             q_placeholder: Search...

--- a/src/Resources/translations/messages.de.yaml
+++ b/src/Resources/translations/messages.de.yaml
@@ -11,6 +11,7 @@ setono_sylius_meilisearch:
                 body: 'Versuchen Sie, nach etwas anderem zu suchen'
                 header: 'Keine Ergebnisse gefunden'
             pagination:
+                label: 'Seitennummerierung'
                 next: Next
                 previous: Previous
             q_placeholder: Search...

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -11,6 +11,7 @@ setono_sylius_meilisearch:
                 body: 'Try to search for something else'
                 header: 'No results found'
             pagination:
+                label: 'Pagination'
                 next: Next
                 previous: Previous
             q_placeholder: Search...

--- a/src/Resources/translations/messages.es.yaml
+++ b/src/Resources/translations/messages.es.yaml
@@ -11,6 +11,7 @@ setono_sylius_meilisearch:
                 body: 'Intenta buscar otra cosa'
                 header: 'No se encontraron resultados'
             pagination:
+                label: 'Paginación'
                 next: Next
                 previous: Previous
             q_placeholder: Search...

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -11,6 +11,7 @@ setono_sylius_meilisearch:
                 body: 'Essayez de rechercher autre chose'
                 header: 'Aucun résultat trouvé'
             pagination:
+                label: 'Pagination'
                 next: Next
                 previous: Previous
             q_placeholder: Search...

--- a/src/Resources/translations/messages.it.yaml
+++ b/src/Resources/translations/messages.it.yaml
@@ -11,6 +11,7 @@ setono_sylius_meilisearch:
                 body: 'Prova a cercare qualcos''altro'
                 header: 'Nessun risultato trovato'
             pagination:
+                label: 'Impaginazione'
                 next: Next
                 previous: Previous
             q_placeholder: Search...

--- a/src/Resources/translations/messages.lt.yaml
+++ b/src/Resources/translations/messages.lt.yaml
@@ -11,6 +11,7 @@ setono_sylius_meilisearch:
                 body: 'Pabandykite ieškoti ko nors kito'
                 header: 'Rezultatų nerasta'
             pagination:
+                label: 'Puslapiavimas'
                 next: Next
                 previous: Previous
             q_placeholder: Search...

--- a/src/Resources/translations/messages.nl.yaml
+++ b/src/Resources/translations/messages.nl.yaml
@@ -11,6 +11,7 @@ setono_sylius_meilisearch:
                 body: 'Probeer iets anders te zoeken'
                 header: 'Geen resultaten gevonden'
             pagination:
+                label: 'Paginering'
                 next: Next
                 previous: Previous
             q_placeholder: Search...

--- a/src/Resources/translations/messages.no.yaml
+++ b/src/Resources/translations/messages.no.yaml
@@ -11,6 +11,7 @@ setono_sylius_meilisearch:
                 body: 'Prøv å søke etter noe annet'
                 header: 'Ingen resultater funnet'
             pagination:
+                label: 'Paginering'
                 next: Next
                 previous: Previous
             q_placeholder: Search...

--- a/src/Resources/translations/messages.pl.yaml
+++ b/src/Resources/translations/messages.pl.yaml
@@ -11,6 +11,7 @@ setono_sylius_meilisearch:
                 body: 'Spróbuj wyszukać coś innego'
                 header: 'Nie znaleziono wyników'
             pagination:
+                label: 'Paginacja'
                 next: Next
                 previous: Previous
             q_placeholder: Search...

--- a/src/Resources/translations/messages.ro.yaml
+++ b/src/Resources/translations/messages.ro.yaml
@@ -11,6 +11,7 @@ setono_sylius_meilisearch:
                 body: 'Încearcă să cauți altceva'
                 header: 'Niciun rezultat găsit'
             pagination:
+                label: 'Paginare'
                 next: Next
                 previous: Previous
             q_placeholder: Search...

--- a/src/Resources/translations/messages.sv.yaml
+++ b/src/Resources/translations/messages.sv.yaml
@@ -11,6 +11,7 @@ setono_sylius_meilisearch:
                 body: 'Försök att söka efter något annat'
                 header: 'Inga resultat hittades'
             pagination:
+                label: 'Paginering'
                 next: Next
                 previous: Previous
             q_placeholder: Search...

--- a/src/Resources/views/form/search_theme.html.twig
+++ b/src/Resources/views/form/search_theme.html.twig
@@ -38,15 +38,3 @@
     </div>
 {% endblock %}
 
-{% block setono_sylius_meilisearch_page_choice_widget %}
-    <nav class="ssm-pagination">
-        <ol>
-            {%- for child in form %}
-                <li{{ child.vars.label == '__current' ? ' style="display:none"' : '' }}>
-                    {{- form_widget(child) -}}
-                    {{- form_label(child, null, {translation_domain: choice_translation_domain}) -}}
-                </li>
-            {% endfor -%}
-        </ol>
-    </nav>
-{% endblock %}

--- a/src/Resources/views/search/_pagination.html.twig
+++ b/src/Resources/views/search/_pagination.html.twig
@@ -1,3 +1,53 @@
-{% if searchForm.p is defined %}
-    {{ form_widget(searchForm.p) }}
+{# @var searchResult \Setono\SyliusMeilisearchPlugin\Engine\SearchResult #}
+{% set current = searchResult.page %}
+{% set total = searchResult.totalPages %}
+
+{% if total > 1 %}
+    {# Preserve the current route (search or taxon), its params (e.g. _locale, slug) and the
+       current query (q, f, s), only overriding the page. #}
+    {% set route = app.request.attributes.get('_route') %}
+    {% set routeParams = (app.request.attributes.get('_route_params')|default({}))|merge(app.request.query.all) %}
+
+    {# Build a windowed list of page numbers: first, last and a window around the current page. #}
+    {% set pages = [] %}
+    {% for page in 1..total %}
+        {% if page == 1 or page == total or (page >= current - 2 and page <= current + 2) %}
+            {% set pages = pages|merge([page]) %}
+        {% endif %}
+    {% endfor %}
+
+    <nav class="ssm-pagination" aria-label="{{ 'setono_sylius_meilisearch.form.search.pagination.label'|trans }}">
+        <ul>
+            {% if current > 1 %}
+                <li class="ssm-pagination-previous">
+                    <a rel="prev" href="{{ path(route, routeParams|merge({'p': current - 1})) }}">
+                        {{ 'setono_sylius_meilisearch.form.search.pagination.previous'|trans }}
+                    </a>
+                </li>
+            {% endif %}
+
+            {% set previousPage = 0 %}
+            {% for page in pages %}
+                {% if previousPage and page > previousPage + 1 %}
+                    <li class="ssm-pagination-ellipsis" aria-hidden="true">&hellip;</li>
+                {% endif %}
+
+                <li>
+                    <a href="{{ path(route, routeParams|merge({'p': page})) }}"{{ page == current ? ' aria-current="page"' : '' }}>
+                        {{ page }}
+                    </a>
+                </li>
+
+                {% set previousPage = page %}
+            {% endfor %}
+
+            {% if current < total %}
+                <li class="ssm-pagination-next">
+                    <a rel="next" href="{{ path(route, routeParams|merge({'p': current + 1})) }}">
+                        {{ 'setono_sylius_meilisearch.form.search.pagination.next'|trans }}
+                    </a>
+                </li>
+            {% endif %}
+        </ul>
+    </nav>
 {% endif %}

--- a/tests/Application/e2e/search.spec.ts
+++ b/tests/Application/e2e/search.spec.ts
@@ -32,15 +32,18 @@ test.describe('shop search page', () => {
         await page.goto('/en_US/search?q=jeans');
         const firstOnPage1 = await names(page).first().textContent();
 
-        // Pagination is Previous/Next; clicking "Next" fires an AJAX submit + pushState
-        await page.locator('nav.ssm-pagination label', { hasText: 'Next' }).click();
+        // Pagination is anchor links; clicking "Next" (rel=next) fires an AJAX submit + pushState
+        await page.locator('nav.ssm-pagination a[rel="next"]').click();
         await expect(page).toHaveURL(/[?&]p=2(&|$)/);
         await expect(names(page).first()).not.toHaveText(firstOnPage1 ?? '');
+
+        // The current page link is marked aria-current
+        await expect(page.locator('nav.ssm-pagination a[aria-current="page"]')).toHaveText('2');
 
         // Last page holds the remaining 2 of 8 hits and has no "Next" control
         await page.goto('/en_US/search?q=jeans&p=3');
         await expect(names(page)).toHaveCount(2);
-        await expect(page.locator('nav.ssm-pagination label', { hasText: 'Next' })).toHaveCount(0);
+        await expect(page.locator('nav.ssm-pagination a[rel="next"]')).toHaveCount(0);
     });
 
     test('filters by a brand facet', async ({ page }) => {

--- a/tests/Functional/PaginationRenderingTest.php
+++ b/tests/Functional/PaginationRenderingTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Functional;
+
+use Setono\SyliusMeilisearchPlugin\Config\IndexRegistryInterface;
+use Setono\SyliusMeilisearchPlugin\Engine\FacetDistribution;
+use Setono\SyliusMeilisearchPlugin\Engine\SearchResult;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Environment;
+
+final class PaginationRenderingTest extends FunctionalTestCase
+{
+    public function testItRendersAccessibleAnchorPagination(): void
+    {
+        $container = self::getContainer();
+
+        /** @var RequestStack $requestStack */
+        $requestStack = $container->get('request_stack');
+        $request = Request::create('/en_US/search?q=jeans&p=2');
+        $request->attributes->set('_route', 'setono_sylius_meilisearch_shop_search');
+        $request->attributes->set('_route_params', ['_locale' => 'en_US']);
+        $requestStack->push($request);
+
+        /** @var IndexRegistryInterface $indexRegistry */
+        $indexRegistry = $container->get('setono_sylius_meilisearch.config.index_registry');
+        $searchResult = new SearchResult(
+            $indexRegistry->get('products'),
+            [],
+            totalHits: 8,
+            page: 2,
+            pageSize: 3,
+            totalPages: 3,
+            facetDistribution: new FacetDistribution([], []),
+        );
+
+        /** @var Environment $twig */
+        $twig = $container->get('twig');
+        $html = $twig->render('@SetonoSyliusMeilisearchPlugin/search/_pagination.html.twig', ['searchResult' => $searchResult]);
+
+        self::assertStringContainsString('<nav class="ssm-pagination"', $html);
+        // Keyboard-accessible anchor links, no radio inputs
+        self::assertStringContainsString('<a ', $html);
+        self::assertStringNotContainsString('<input', $html);
+        // On page 2 of 3 there is a prev and a next link, and the current page is marked
+        self::assertStringContainsString('rel="prev"', $html);
+        self::assertStringContainsString('rel="next"', $html);
+        self::assertStringContainsString('aria-current="page"', $html);
+    }
+}


### PR DESCRIPTION
## What

Pagination was built as an expanded `ChoiceType` whose radio inputs got `style="display: none"` — `display:none` removes them from the tab order entirely, so **keyboard and screen-reader users could not paginate at all** — and only Previous/Next existed.

It's now real **anchor links** built from the current `SearchRequest`: a `<nav aria-label="Pagination">` with numbered pages (windowed around the current page, plus first/last with an ellipsis), `rel="prev"`/`rel="next"` on the Previous/Next links, and `aria-current="page"` on the current page. That is keyboard-accessible, screen-reader-friendly, crawlable, and works without JS by construction. `search.js` intercepts plain left-clicks for the AJAX path (same swap logic; modified clicks fall through to normal navigation).

The radio-based `p` field is dropped from the form (`p` is still read from the query string — and because the form no longer carries `p`, a filter change now naturally resets to page 1). The `pagination.label` key is added to all 12 locales, and the obsolete `page_choice_widget` form-theme block is removed.

## Testing

- `PaginationRenderingTest` (Functional): renders the partial and asserts anchor links, no `<input>`, `rel="prev"`/`rel="next"`, and `aria-current="page"`.
- e2e `paginates through the result set` updated to click `nav.ssm-pagination a[rel="next"]` and assert `aria-current`.
- Twig lint passes; the functional pagination/sorting engine tests still pass.

Closes #123

---
_Stacked on #167 (#122)._