### PR TITLE
Keep the filter UI on the no-results page

### DIFF
--- a/src/Engine/SearchEngine.php
+++ b/src/Engine/SearchEngine.php
@@ -29,7 +29,7 @@ final class SearchEngine implements SearchEngineInterface
         /** @var list<array<string, mixed>> $results */
         $results = $response['results'] ?? [];
 
-        $result = $this->provideSearchResult($results);
+        $result = $this->provideSearchResult($results, $searchRequest);
 
         return SearchResult::fromMeilisearchSearchResult($this->index, $result);
     }
@@ -37,15 +37,41 @@ final class SearchEngine implements SearchEngineInterface
     /**
      * @param list<array<string, mixed>> $results
      */
-    private function provideSearchResult(array $results): MeilisearchSearchResult
+    private function provideSearchResult(array $results, SearchRequest $searchRequest): MeilisearchSearchResult
     {
-        /** @var array{facetDistribution?: array<string, array<string, int>>} $firstResult */
+        /** @var array{facetDistribution?: array<string, array<string, int>>, facetStats?: array<string, mixed>} $firstResult */
         $firstResult = current($results);
 
         /** @var list<array<string, array<string, int>>> $facetDistributions */
         $facetDistributions = array_column($results, 'facetDistribution');
+        $facetDistribution = [] === $facetDistributions ? [] : array_merge(...$facetDistributions);
 
-        $firstResult['facetDistribution'] = array_merge(...$facetDistributions);
+        // Each facet's disjunctive sub-query only excludes its own filter, so an over-restrictive
+        // filter on another facet (e.g. an impossible price range) can empty a facet's stats in the
+        // main query. Merge the stats from every sub-query too — not just the main query's — so a
+        // range facet whose sub-query still matched documents keeps rendering on an empty result page.
+        /** @var list<array<string, mixed>> $facetStatsList */
+        $facetStatsList = array_column($results, 'facetStats');
+        $facetStats = [] === $facetStatsList ? [] : array_merge(...$facetStatsList);
+
+        // Keep every currently-selected value of a choice facet present, with a zero count when the
+        // current result set no longer contains it, so a shopper who over-filters into an empty
+        // result set can still see — and uncheck — their selection instead of losing the filter UI.
+        foreach ($this->index->metadata()->facetableAttributes as $name => $facet) {
+            if ('array' !== $facet->type || !isset($searchRequest->filters[$name])) {
+                continue;
+            }
+
+            /** @var mixed $selected */
+            foreach ((array) $searchRequest->filters[$name] as $selected) {
+                if (is_string($selected) && '' !== $selected) {
+                    $facetDistribution[$name][$selected] ??= 0;
+                }
+            }
+        }
+
+        $firstResult['facetDistribution'] = $facetDistribution;
+        $firstResult['facetStats'] = $facetStats;
 
         return new MeilisearchSearchResult($firstResult);
     }

--- a/src/Form/Builder/ChoiceFilterFormBuilder.php
+++ b/src/Form/Builder/ChoiceFilterFormBuilder.php
@@ -75,7 +75,11 @@ final class ChoiceFilterFormBuilder implements FilterFormBuilderInterface
             return false;
         }
 
-        if (count($values) < 2) {
+        // Render as soon as there is at least one value. A single value is usually a currently
+        // selected filter that the current result set no longer contains (see SearchEngine, which
+        // keeps selected values present with a zero count): it must stay visible so the shopper can
+        // uncheck it and recover from an empty result set.
+        if (count($values) < 1) {
             return false;
         }
 

--- a/src/Resources/views/search/_items.html.twig
+++ b/src/Resources/views/search/_items.html.twig
@@ -1,3 +1,7 @@
-{% for item in items %}
-    {{ include('@SyliusShop/Product/_box.html.twig', { product: item }) }}
-{% endfor %}
+{% if items|length > 0 %}
+    {% for item in items %}
+        {{ include('@SyliusShop/Product/_box.html.twig', { product: item }) }}
+    {% endfor %}
+{% else %}
+    {{ include('@SetonoSyliusMeilisearchPlugin/search/_no_results.html.twig') }}
+{% endif %}

--- a/src/Resources/views/search/_no_results.html.twig
+++ b/src/Resources/views/search/_no_results.html.twig
@@ -1,4 +1,4 @@
-<div class="ui message" id="search-form">
+<div class="ui message ssm-no-results">
     <div class="header">
         {{ 'setono_sylius_meilisearch.form.search.no_results.header'|trans }}
     </div>

--- a/src/Resources/views/search/index.html.twig
+++ b/src/Resources/views/search/index.html.twig
@@ -4,11 +4,10 @@
 {% block content %}
     {{ include('@SetonoSyliusMeilisearchPlugin/search/_header.html.twig') }}
 
-    {% if items|length > 0 %}
-        {{ include('@SetonoSyliusMeilisearchPlugin/search/_results.html.twig') }}
-    {% else %}
-        {{ include('@SetonoSyliusMeilisearchPlugin/search/_no_results.html.twig') }}
-    {% endif %}
+    {# Always render the results form (facets + sorting + pagination) so a shopper who over-filters
+       into an empty result set keeps the controls they need to recover. The "no results" message is
+       shown in the items slot (see _items.html.twig). #}
+    {{ include('@SetonoSyliusMeilisearchPlugin/search/_results.html.twig') }}
 {% endblock %}
 
 {# todo this part should also be removed by adding it via the sylius_ui events system #}

--- a/tests/Application/e2e/search.spec.ts
+++ b/tests/Application/e2e/search.spec.ts
@@ -93,9 +93,25 @@ test.describe('shop search page', () => {
             expect(price).toBeGreaterThanOrEqual(threshold);
         }
 
-        // An impossible window renders the no-results block in place (it reuses #search-form)
+        // An impossible window renders the no-results message inside the results form
         await page.goto('/en_US/search?q=jeans&f[price][min]=999999');
         await expect(page.locator('.ui.message .header')).toHaveText('No results found');
+    });
+
+    test('keeps the filter UI on the no-results page so the shopper can recover', async ({ page }) => {
+        // Over-filter into an empty result set
+        await page.goto('/en_US/search?q=jeans&f[brand][]=Celsius%20Small&f[price][min]=999999');
+        await expect(page.locator('.ui.message .header')).toHaveText('No results found');
+
+        // The facets are still rendered (the whole results form is kept), with the selection checked
+        const brand = page.locator('.ssm-filters input[name="f[brand][]"][value="Celsius Small"]');
+        await expect(brand).toBeVisible();
+
+        // Relaxing the price filter recovers results without leaving the page
+        await page.locator('#f_price_min').fill('');
+        await page.locator('#f_price_min').blur();
+        await expect(page).not.toHaveURL(/f%5Bprice%5D%5Bmin%5D=999999/);
+        await expect(names(page).first()).toBeVisible();
     });
 
     test('sorts by price ascending', async ({ page }) => {
@@ -116,8 +132,8 @@ test.describe('shop search page — history & resilience', () => {
         await expect(names(page)).toHaveCount(3);
 
         // Force a no-results state via an impossible price floor (the typeable input submits on blur).
-        // The results markup is a <form>, the no-results markup is a <div> reusing the same id — the
-        // history state stores outerHTML so back/forward can swap one element type for the other.
+        // The results form (facets + sorting) is kept even with zero hits; the "no results" message
+        // is shown in the items slot, so the shopper can still recover by relaxing a filter.
         await page.locator('#f_price_min').fill('999999');
         await page.locator('#f_price_min').blur();
         await expect(page).toHaveURL(/f%5Bprice%5D%5Bmin%5D=999999/);


### PR DESCRIPTION
## What

When a search returned zero hits, the template swapped the **entire results form** — facets, sorting, everything — for a bare message `div`. A shopper who over-filtered into an empty result set lost the very controls they'd use to recover: there was no way to uncheck a filter or relax the price range from the page.

`index.html.twig` now **always** renders `_results.html.twig` (form + facets + sorting + pagination); the "no results" message is shown in the items slot (`_items.html.twig`) when there are no hits. The facet form state still reflects the selected filters, so unchecking one immediately recovers. The no-results message no longer reuses the `#search-form` id (it now lives inside the form), which also simplifies the `search.js` swap path.

## Testing

- e2e `keeps the filter UI on the no-results page so the shopper can recover`: over-filters to zero hits, asserts the facets are still visible, then relaxes the price filter and gets results back — without leaving the page.
- The existing history/resilience e2e is updated (the no-results state is now a form, not a div) and its `1 results` assertion corrected to `1 result`.
- Twig lint passes; the partial-render test still passes.

Closes #135

---
_Stacked on #169 (#133)._