### PR TITLE
Search page markup polish: labels, duplicate heading, range defaults

### DIFF
--- a/src/Form/Type/RangeType.php
+++ b/src/Form/Type/RangeType.php
@@ -17,10 +17,14 @@ final class RangeType extends AbstractType
             ->add('min', NumberType::class, [
                 'label' => 'setono_sylius_meilisearch.form.search.range.min',
                 'empty_data' => $options['min'] ?? null,
+                // data-default lets search.js drop the value when it equals the default bound,
+                // so an untouched range filter contributes no f[<facet>][min] param to the URL.
+                'attr' => ['data-default' => $options['min']],
             ])
             ->add('max', NumberType::class, [
                 'label' => 'setono_sylius_meilisearch.form.search.range.max',
                 'empty_data' => $options['max'] ?? null,
+                'attr' => ['data-default' => $options['max']],
             ])
         ;
     }

--- a/src/Resources/public/js/search.js
+++ b/src/Resources/public/js/search.js
@@ -386,9 +386,18 @@ class SearchManager {
         url.search = '';
 
         formData.forEach((value, key) => {
-            if (value !== '') {
-                url.searchParams.append(key, value);
+            if (value === '') {
+                return;
             }
+
+            // Drop a value that still equals its default (e.g. an untouched range bound), so an
+            // unchanged range filter doesn't clutter the URL or force a needless round-trip.
+            const field = this.#form.elements.namedItem(key);
+            if (field instanceof HTMLInputElement && field.dataset.default !== undefined && field.dataset.default === value) {
+                return;
+            }
+
+            url.searchParams.append(key, value);
         });
 
         return url.toString();

--- a/src/Resources/views/form/search_theme.html.twig
+++ b/src/Resources/views/form/search_theme.html.twig
@@ -1,6 +1,5 @@
 {% block setono_sylius_meilisearch_facet_checkbox_row %}
     <div class="ssm-filter ssm-filter-checkbox">
-        {{ form_label(form) }}
         <ul>
             <li>{{- form_widget(form) -}}{{ form_label(form) }}</li>
         </ul>
@@ -10,15 +9,16 @@
 {% block setono_sylius_meilisearch_facet_range_row %}
     <div class="ssm-filter ssm-filter-range">
         {{ form_label(form) }}
-        {# todo these input fields should be prefilled with min and max values, but should not be submitted if those values are equal to the default value #}
+        {# The inputs are prefilled with the current result set's bounds (via data-default). search.js
+           drops any value that still equals its default, so untouched inputs add no params to the URL. #}
         <div class="ssm-filter-range-widget">
             <div>
                 {{ form_label(form.min) }}
-                {{ form_widget(form.min) }}
+                {{ form_widget(form.min, { 'value': form.min.vars.value ?: form.min.vars.attr['data-default']|default('') }) }}
             </div>
             <div>
                 {{ form_label(form.max) }}
-                {{ form_widget(form.max) }}
+                {{ form_widget(form.max, { 'value': form.max.vars.value ?: form.max.vars.attr['data-default']|default('') }) }}
             </div>
         </div>
     </div>

--- a/src/Resources/views/search/_sorting.html.twig
+++ b/src/Resources/views/search/_sorting.html.twig
@@ -1,1 +1,2 @@
-{{ form_widget(searchForm.s, { 'attr': { 'class': 'ssm-sort' } }) }}
+{# aria-label gives the select a programmatic label without a visible one (placeholder-only UI) #}
+{{ form_widget(searchForm.s, { 'attr': { 'class': 'ssm-sort', 'aria-label': 'setono_sylius_meilisearch.form.search.sorting.placeholder'|trans } }) }}

--- a/src/Resources/views/search_widget/_content.html.twig
+++ b/src/Resources/views/search_widget/_content.html.twig
@@ -3,7 +3,8 @@
 <div class="ui center aligned column">
     {{ form_start(form, { 'action': path('setono_sylius_meilisearch_shop_search'), 'attr': { 'class': 'ui form' } }) }}
         <div class="two fields">
-            {{ form_row(form.q) }}
+            {# aria-label gives the placeholder-only search input a programmatic label #}
+            {{ form_row(form.q, { 'attr': { 'aria-label': 'setono_sylius_meilisearch.form.search.q_placeholder'|trans } }) }}
             <button type="submit" class="ui icon button">
                 {{ 'setono_sylius_meilisearch.ui.search'|trans }}
                 <i class="search icon"></i>

--- a/tests/Application/e2e/search.spec.ts
+++ b/tests/Application/e2e/search.spec.ts
@@ -87,6 +87,8 @@ test.describe('shop search page', () => {
         await min.fill(String(threshold));
         await min.blur();
         await expect(page).toHaveURL(/f%5Bprice%5D%5Bmin%5D/);
+        // The untouched max input still equals its default, so it contributes no param to the URL
+        await expect(page).not.toHaveURL(/f%5Bprice%5D%5Bmax%5D/);
 
         await expect(names(page).first()).toBeVisible();
         for (const price of await prices(page)) {


### PR DESCRIPTION
## What

A bundle of small markup/UX fixes on the search page:

1. **Duplicate label on checkbox facets** — the facet label was rendered twice (once above the `<ul>`, once next to the widget), so a boolean facet like "On sale (5)" printed its heading twice. Now rendered once.
2. **Placeholder-only inputs** — the search widget input and the sort select had only a placeholder (not a programmatic label). Both now carry a translated `aria-label`, so screen readers and axe/lighthouse see a label.
3. **Range filter default bounds** (acknowledged todo) — the range inputs are prefilled with the current result set's bounds via `data-default`, and `search.js` now drops any submitted value that still equals its default (it previously only dropped empty ones). So touching, but not changing, a range input no longer submits `f[<facet>][min|max]` equal to the full range.

**Deferred:** rendering the results grid as `<ul>/<li>` — the current grid relies on Semantic UI's `.cards > .card` direct-child styling, so it needs a visual review to avoid a layout regression, and is left as a follow-up.

## Testing

- e2e range test now asserts the untouched `max` input contributes no `f[price][max]` param to the URL.
- Twig lint passes; PHPStan/ECS clean.

Closes #137

---
_Stacked on #170 (#135)._