### PR TITLE
Autocomplete: show price, add a see-all link, debounce requests

### DIFF
--- a/src/Meilisearch/Autocomplete/Configuration/Configuration.php
+++ b/src/Meilisearch/Autocomplete/Configuration/Configuration.php
@@ -20,6 +20,9 @@ final class Configuration
         public readonly string $placeholder,
         public readonly ?string $searchPath = null,
         public readonly ?string $searchParameter = 'q',
+
+        /** Label for the "see all results" link in each source footer */
+        public readonly ?string $seeAllLabel = null,
         public readonly bool $debug = false,
     ) {
     }

--- a/src/Resources/public/js/autocomplete.js
+++ b/src/Resources/public/js/autocomplete.js
@@ -26,8 +26,9 @@
      * @property {string} searchKey - Search-only Meilisearch API key.
      * @property {string} container - CSS selector the autocomplete mounts into.
      * @property {string} placeholder - Input placeholder text.
-     * @property {?string} searchPath - URL of the search results page (used by onSubmit).
+     * @property {?string} searchPath - URL of the search results page (used by onSubmit and the see-all footer).
      * @property {?string} searchParameter - Query-string parameter carrying the search query.
+     * @property {?string} seeAllLabel - Label for the "see all results" footer link.
      * @property {boolean} debug - Keeps the panel open for inspection when true.
      * @property {Source[]} sources - Sources to search.
      */
@@ -74,6 +75,27 @@
     const compileTemplate = (template) =>
         new Function('{ item, components, html }', 'return html`' + template + '`;');
 
+    /**
+     * Debounces a promise-returning function: only the most recent call within `time` ms resolves.
+     * Used so a fast typer doesn't fire one Meilisearch request per character (stale-response
+     * ordering is already handled by the library, so this is purely a load win).
+     */
+    function debouncePromise(fn, time) {
+        let timer;
+
+        return (...args) => {
+            if (timer) {
+                clearTimeout(timer);
+            }
+
+            return new Promise((resolve) => {
+                timer = setTimeout(() => resolve(fn(...args)), time);
+            });
+        };
+    }
+
+    const debounced = debouncePromise((sources) => sources, 200);
+
     const autocompleteConfig = {
         debug: configuration.debug,
         container: configuration.container,
@@ -99,7 +121,7 @@
             return { source, templates };
         });
 
-        autocompleteConfig.getSources = ({ query }) => compiledSources.map(({ source, templates }) => {
+        autocompleteConfig.getSources = ({ query }) => debounced(compiledSources.map(({ source, templates }) => {
             const s = {
                 sourceId: source.id,
                 getItems() {
@@ -116,8 +138,26 @@
                 },
             };
 
-            if (Object.keys(templates).length !== 0) {
-                s.templates = templates;
+            const sourceTemplates = { ...templates };
+
+            // A "see all results" footer linking to the full search page for the current query.
+            if (configuration.searchPath && configuration.searchParameter && query !== '') {
+                const seeAllUrl = new URL(configuration.searchPath, window.location.origin);
+                seeAllUrl.searchParams.set(configuration.searchParameter, query);
+
+                sourceTemplates.footer = ({ items, html }) => {
+                    if (items.length === 0) {
+                        return '';
+                    }
+
+                    return html`<div class="aa-SourceFooter">
+                        <a class="aa-SeeAllLink" href="${seeAllUrl.toString()}">${configuration.seeAllLabel || 'See all results'}</a>
+                    </div>`;
+                };
+            }
+
+            if (Object.keys(sourceTemplates).length !== 0) {
+                s.templates = sourceTemplates;
             }
 
             if (source.urlAttribute) {
@@ -127,7 +167,7 @@
             }
 
             return s;
-        });
+        }));
     }
 
     if (configuration.searchParameter) {

--- a/src/Resources/translations/messages.da.yaml
+++ b/src/Resources/translations/messages.da.yaml
@@ -1,4 +1,6 @@
 setono_sylius_meilisearch:
+    autocomplete:
+        see_all_results: 'Se alle resultater'
     form:
         search:
             facet:

--- a/src/Resources/translations/messages.de.yaml
+++ b/src/Resources/translations/messages.de.yaml
@@ -1,4 +1,6 @@
 setono_sylius_meilisearch:
+    autocomplete:
+        see_all_results: 'Alle Ergebnisse anzeigen'
     form:
         search:
             facet:

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -1,4 +1,6 @@
 setono_sylius_meilisearch:
+    autocomplete:
+        see_all_results: 'See all results'
     form:
         search:
             facet:

--- a/src/Resources/translations/messages.es.yaml
+++ b/src/Resources/translations/messages.es.yaml
@@ -1,4 +1,6 @@
 setono_sylius_meilisearch:
+    autocomplete:
+        see_all_results: 'Ver todos los resultados'
     form:
         search:
             facet:

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -1,4 +1,6 @@
 setono_sylius_meilisearch:
+    autocomplete:
+        see_all_results: 'Voir tous les résultats'
     form:
         search:
             facet:

--- a/src/Resources/translations/messages.it.yaml
+++ b/src/Resources/translations/messages.it.yaml
@@ -1,4 +1,6 @@
 setono_sylius_meilisearch:
+    autocomplete:
+        see_all_results: 'Vedi tutti i risultati'
     form:
         search:
             facet:

--- a/src/Resources/translations/messages.lt.yaml
+++ b/src/Resources/translations/messages.lt.yaml
@@ -1,4 +1,6 @@
 setono_sylius_meilisearch:
+    autocomplete:
+        see_all_results: 'Žiūrėti visus rezultatus'
     form:
         search:
             facet:

--- a/src/Resources/translations/messages.nl.yaml
+++ b/src/Resources/translations/messages.nl.yaml
@@ -1,4 +1,6 @@
 setono_sylius_meilisearch:
+    autocomplete:
+        see_all_results: 'Alle resultaten bekijken'
     form:
         search:
             facet:

--- a/src/Resources/translations/messages.no.yaml
+++ b/src/Resources/translations/messages.no.yaml
@@ -1,4 +1,6 @@
 setono_sylius_meilisearch:
+    autocomplete:
+        see_all_results: 'Se alle resultater'
     form:
         search:
             facet:

--- a/src/Resources/translations/messages.pl.yaml
+++ b/src/Resources/translations/messages.pl.yaml
@@ -1,4 +1,6 @@
 setono_sylius_meilisearch:
+    autocomplete:
+        see_all_results: 'Zobacz wszystkie wyniki'
     form:
         search:
             facet:

--- a/src/Resources/translations/messages.ro.yaml
+++ b/src/Resources/translations/messages.ro.yaml
@@ -1,4 +1,6 @@
 setono_sylius_meilisearch:
+    autocomplete:
+        see_all_results: 'Vezi toate rezultatele'
     form:
         search:
             facet:

--- a/src/Resources/translations/messages.sv.yaml
+++ b/src/Resources/translations/messages.sv.yaml
@@ -1,4 +1,6 @@
 setono_sylius_meilisearch:
+    autocomplete:
+        see_all_results: 'Visa alla resultat'
     form:
         search:
             facet:

--- a/src/Resources/views/autocomplete/templates/item.html.twig
+++ b/src/Resources/views/autocomplete/templates/item.html.twig
@@ -4,6 +4,8 @@
         ${item.image ? html`<div class="aa-ItemIcon aa-ItemIcon--alignTop"><img src="${item.image}" alt="${item.name}" width="100"/></div>` : ''}
         <div class="aa-ItemContentBody">
             <div class="aa-ItemContentTitle">${components.Highlight({hit: item, attribute: 'name'})}</div>
+            {# item.price is set on product documents (channel/currency-scoped). Guard it so non-product sources render nothing. #}
+            ${item.price != null ? html`<div class="aa-ItemContentDescription">${new Intl.NumberFormat(undefined, { style: 'currency', currency: item.currency || 'USD' }).format(item.price)}</div>` : ''}
         </div>
     </div>
 </div>

--- a/src/Twig/AutocompleteRuntime.php
+++ b/src/Twig/AutocompleteRuntime.php
@@ -35,6 +35,7 @@ final class AutocompleteRuntime implements RuntimeExtensionInterface
             container: $this->container,
             placeholder: $this->translator->trans($this->placeholder),
             searchPath: $this->urlGenerator->generate('setono_sylius_meilisearch_shop_search'),
+            seeAllLabel: $this->translator->trans('setono_sylius_meilisearch.autocomplete.see_all_results'),
             debug: $this->debug,
         );
 

--- a/tests/Application/e2e/autocomplete.spec.ts
+++ b/tests/Application/e2e/autocomplete.spec.ts
@@ -29,6 +29,42 @@ test.describe('autocomplete widget', () => {
         await expect(page.locator('.aa-ItemContentTitle').filter({ hasText: /jeans/i }).first()).toBeVisible();
     });
 
+    test('shows the price and a see-all link in the suggestions', async ({ page }) => {
+        await page.goto('/en_US/');
+
+        const input = page.locator('#autocomplete .aa-Input');
+        await input.click();
+        await input.pressSequentially('jeans', { delay: 50 });
+
+        // Each product suggestion shows a formatted price
+        await expect(page.locator('.aa-ItemContentDescription').first()).toHaveText(/\d/);
+
+        // A "see all results" footer links to the full search page for the current query
+        const seeAll = page.locator('.aa-SeeAllLink').first();
+        await expect(seeAll).toBeVisible();
+        await expect(seeAll).toHaveAttribute('href', /\/en_US\/search\?q=jeans/);
+    });
+
+    test('debounces Meilisearch requests while typing', async ({ page }) => {
+        await page.goto('/en_US/');
+
+        let meilisearchRequests = 0;
+        page.on('request', (req) => {
+            // The browser queries Meilisearch directly via its multi-search endpoint
+            if (/\/multi-search/.test(req.url())) {
+                meilisearchRequests++;
+            }
+        });
+
+        const input = page.locator('#autocomplete .aa-Input');
+        await input.click();
+        await input.pressSequentially('jeanstrous', { delay: 20 }); // 10 characters typed quickly
+
+        // Let the debounce settle, then assert we didn't fire one request per character
+        await page.waitForTimeout(500);
+        expect(meilisearchRequests).toBeLessThanOrEqual(3);
+    });
+
     test('navigates to the product on selection', async ({ page }) => {
         await page.goto('/en_US/');
 

--- a/tests/Unit/Twig/AutocompleteRuntimeTest.php
+++ b/tests/Unit/Twig/AutocompleteRuntimeTest.php
@@ -25,6 +25,7 @@ final class AutocompleteRuntimeTest extends TestCase
     {
         $translator = $this->prophesize(TranslatorInterface::class);
         $translator->trans('placeholder')->willReturn('Search...');
+        $translator->trans('setono_sylius_meilisearch.autocomplete.see_all_results')->willReturn('See all results');
 
         $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
         $urlGenerator->generate('setono_sylius_meilisearch_shop_search')->willReturn('/search');
@@ -46,5 +47,6 @@ final class AutocompleteRuntimeTest extends TestCase
         self::assertStringContainsString('ssm-autocomplete-configuration', $configuration);
         self::assertStringContainsString('search-only-key', $configuration);
         self::assertStringContainsString('Search...', $configuration);
+        self::assertStringContainsString('See all results', $configuration);
     }
 }


### PR DESCRIPTION
## What

Three improvements to the autocomplete dropdown:

1. **Show the price.** The product index documents are already channel/currency-scoped, so the correct price exists per index. Each suggestion now shows the price, currency-formatted via `Intl.NumberFormat`, guarded so non-product sources render nothing.
2. **"See all results" footer.** Each source now renders a footer link to the full search page for the current query — previously the only path from the dropdown to the results page was knowing to press Enter. The label is translated into all 12 locales and passed through the autocomplete configuration.
3. **Debounce the source (~200 ms).** Previously every keystroke fired a Meilisearch query straight from the browser; fast typers generated one request per character. A `debouncePromise` around the sources coalesces them. Stale-response ordering is already handled by the library, so this is purely a load win.

## Testing

- e2e `shows the price and a see-all link in the suggestions`: asserts a formatted price and a footer link to `search?q=jeans`.
- e2e `debounces Meilisearch requests while typing`: typing 10 characters quickly issues ≤ 3 multi-search requests.
- `AutocompleteRuntimeTest` updated for the new `seeAllLabel`; `node --check` and `lint:container` clean.

Closes #136

---
_Stacked on #171 (#137)._