### PR TITLE
Document that the plugin ships no Symfony Flex recipe yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ composer require setono/sylius-meilisearch-plugin
 
 ### 2. Register the plugin
 
-If you don't use Symfony Flex, add the plugin to your `config/bundles.php` before `SyliusGridBundle`:
+> **No Symfony Flex recipe ships yet** ([#74](https://github.com/Setono/sylius-meilisearch-plugin/issues/74) tracks adding one), so every step in this installation guide is manual — Flex will not register the bundle, configure it, or import the routing for you.
+
+Add the plugin to your `config/bundles.php` before `SyliusGridBundle`:
 
 ```php
 Setono\SyliusMeilisearchPlugin\SetonoSyliusMeilisearchPlugin::class => ['all' => true],


### PR DESCRIPTION
The installation guide is entirely manual — no Symfony Flex recipe registers the bundle, configures it, or imports routing. This adds an explicit callout at the top of the install steps and links #74 (which tracks adding a recipe).

Note: the CHANGELOG and release-drafter automation that were originally part of this PR have been removed per review — this PR now only carries the Flex/manual-install documentation note.