### PR TITLE
Fix build: send synonyms as an object, declare psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "psr/container": "^1.0 || ^2.0",
         "psr/event-dispatcher": "^1.0",
         "psr/http-client": "^1.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "setono/composite-compiler-pass": "^1.2",
         "setono/doctrine-orm-trait": "^1.1",
         "sylius/attribute": "^1.0",

--- a/src/Normalizer/SettingsNormalizer.php
+++ b/src/Normalizer/SettingsNormalizer.php
@@ -30,11 +30,19 @@ final class SettingsNormalizer implements NormalizerInterface
         }
 
         // Only strip null values. Empty arrays are meaningful for list-valued settings
-        // (filterableAttributes, sortableAttributes, stopWords, synonyms, …): because
-        // updateSettings is a *partial* update, sending [] is exactly how you reset such a
-        // setting. Keys that must be omitted when "not configured" are modelled as null in
-        // Settings, not as [].
-        return array_filter($data, static fn (mixed $value): bool => null !== $value);
+        // (filterableAttributes, sortableAttributes, stopWords, …): because updateSettings is a
+        // *partial* update, sending [] is exactly how you reset such a setting. Keys that must be
+        // omitted when "not configured" are modelled as null in Settings, not as [].
+        $data = array_filter($data, static fn (mixed $value): bool => null !== $value);
+
+        // `synonyms` is a map/object in Meilisearch, not a list. An empty PHP array serializes to
+        // the JSON array `[]`, which Meilisearch rejects with "expected an object", so send `{}`
+        // (its reset value) instead when there are no synonyms.
+        if (isset($data['synonyms']) && [] === $data['synonyms']) {
+            $data['synonyms'] = new \stdClass();
+        }
+
+        return $data;
     }
 
     /**

--- a/tests/Unit/Normalizer/SettingsNormalizerTest.php
+++ b/tests/Unit/Normalizer/SettingsNormalizerTest.php
@@ -38,14 +38,33 @@ final class SettingsNormalizerTest extends TestCase
 
         $result = $normalizer->normalize($settings);
 
-        // empty arrays are preserved (sending [] resets a partial-update setting)
+        // empty list-valued settings are preserved (sending [] resets a partial-update setting)
         self::assertArrayHasKey('filterableAttributes', $result);
         self::assertSame([], $result['filterableAttributes']);
         self::assertSame([], $result['sortableAttributes']);
         self::assertSame([], $result['stopWords']);
-        self::assertSame([], $result['synonyms']);
+
+        // synonyms is a map, not a list: empty must be an object so Meilisearch accepts it as {} (not [])
+        self::assertInstanceOf(\stdClass::class, $result['synonyms']);
 
         // null values are still stripped
         self::assertArrayNotHasKey('distinctAttribute', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function it_keeps_a_populated_synonyms_map_as_is(): void
+    {
+        $settings = new Settings();
+
+        $inner = $this->prophesize(NormalizerInterface::class);
+        $inner->normalize($settings, null, [])->willReturn([
+            'synonyms' => ['sneakers' => ['trainers']],
+        ]);
+
+        $result = (new SettingsNormalizer($inner->reveal()))->normalize($settings);
+
+        self::assertSame(['sneakers' => ['trainers']], $result['synonyms']);
     }
 }


### PR DESCRIPTION
Fixes the red (non-BC) CI checks on `master` introduced by this batch.

## Integration & E2E were red — `synonyms` sent as `[]`

Meilisearch requires the `synonyms` setting to be an **object**. Keeping empty arrays in `SettingsNormalizer` (from the empty-array-reset change) meant an empty `synonyms` serialized to the JSON array `[]`, which Meilisearch rejects:

```
Invalid value type at `.synonyms`: expected an object, but found an array: `[]`
```

So `updateSettings` 400'd and the whole `setono:sylius-meilisearch:index` command failed — breaking the CI setup for the Integration and E2E suites. Now an empty `synonyms` is sent as `{}` (its reset value). Verified locally: `bin/console setono:sylius-meilisearch:index` now exits 0 and the functional `SearchTest` passes.

## Dependency Analysis was red — `psr/log` shadow dependency

The indexing logger uses `Psr\Log\*` in `src/`, but `psr/log` was only available transitively. Declared it in `require`.

## Testing

- `SettingsNormalizerTest`: empty `synonyms` normalizes to a `\stdClass` (`{}`); a populated synonyms map is kept as-is.
- Ran the index command end-to-end against Meilisearch (exit 0) and the functional `SearchTest` (green).

> The `symfony/translation` dev-dependency finding (from `FacetLabelTrait` in #134) is fixed on that PR's branch; the BC check stays red by design (no stable release).