### PR TITLE
Give the test app its own Meilisearch instead of a shared :7700

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,17 +22,26 @@ After changing code, run `composer fix-style`, `composer analyse`, and `(cd test
 
 ### Functional tests
 
-The Functional suite needs MariaDB/MySQL and Meilisearch on `:7700` with master key `aSampleMasterKey`. Start Meilisearch with `cd tests/Application && docker compose up -d --wait` (or `tests/Application/meilisearch.sh` without Docker; the CI service container is in `.github/workflows/build.yaml`). Keep the compose image version in sync with the CI service containers. Setup chain (all from `tests/Application`, with `APP_ENV=test` — the test env ignores `.env.local`, which may hold real cloud credentials):
+The Functional suite needs MariaDB/MySQL and Meilisearch with master key `aSampleMasterKey`. Start Meilisearch with `cd tests/Application && docker compose up -d --wait` (or `tests/Application/meilisearch.sh` without Docker; the CI service container is in `.github/workflows/build.yaml`). Keep the compose image version in sync with the CI service containers.
+
+**The compose stack binds Meilisearch to a random host port**, so it can never collide with another Meilisearch you happen to run — a fixed `:7700` meant a neighbouring project's container would answer instead, and the suite would silently index into and search *that* instance. The Symfony CLI resolves the port automatically: because the compose service is named `meilisearch`, it injects `MEILISEARCH_URL` (plus `MEILISEARCH_HOST`/`MEILISEARCH_PORT`) pointing at the published port, which overrides the `MEILISEARCH_URL` in `tests/Application/.env`. The CLI reports the scheme as `tcp://` for a Docker service on a port it does not recognise; `SetonoSyliusMeilisearchExtension::normalizeServerUrl()` already coerces that to `http`, so nothing extra is needed. The `.env` value (`:7700`) stays as the fallback for CI's service container and `meilisearch.sh`.
+
+**This means every command that talks to Meilisearch must run through the Symfony CLI** (`symfony console`, `symfony php`) — plain `bin/console`/`vendor/bin/phpunit` fall back to `:7700` and will miss the container. The CLI matches containers by Docker Compose project name and resolves the project from the *script's* location, so it only finds the stack when the compose file is in scope: `vendor/bin/phpunit` lives at the repo root, so it has to be run from `tests/Application` (`symfony php ../../vendor/bin/phpunit -c ../..`). `composer phpunit-functional` wraps exactly that. Setup chain (from `tests/Application`, with `APP_ENV=test` — the test env ignores `.env.local`, which may hold real cloud credentials):
 
 ```shell
-bin/console doctrine:database:create
-bin/console doctrine:schema:create
-bin/console sylius:fixtures:load -n
-bin/console setono:sylius-meilisearch:index --wait
-cd ../.. && vendor/bin/phpunit --testsuite Functional
+symfony console doctrine:database:create
+symfony console doctrine:schema:create
+symfony console sylius:fixtures:load -n
+symfony console cache:clear                          # see the port caveat below
+symfony console setono:sylius-meilisearch:index --wait
+cd ../.. && composer phpunit-functional
 ```
 
-Note: repeated fixture loads accumulate stale documents in a long-lived local Meilisearch (indexes are only added to, never purged), which can make index-vs-database comparisons drift. `docker compose down && docker compose up -d` resets the instance (the compose service has no volume); CI uses a fresh container per run.
+Note `APP_ENV`: under the Symfony CLI the value comes from the CLI's own dotenv handling, so PHPUnit's `<env name="APP_ENV">` in `phpunit.xml.dist` does *not* win — pass `APP_ENV=test` explicitly (the composer script does).
+
+**The port changes whenever the container is recreated, and the plugin bakes the URL into the compiled container** (the extension calls `resolveEnvPlaceholders()` at compile time), so run `symfony console cache:clear` after `docker compose up`, or the app keeps calling the previous port. A stale cache fails loudly with a connection error rather than silently hitting another instance.
+
+Note: repeated fixture loads accumulate stale documents in a long-lived local Meilisearch (indexes are only added to, never purged), which can make index-vs-database comparisons drift. `docker compose down && docker compose up -d` resets the instance (the compose service has no volume) — remember it comes back on a new port and empty, so clear the cache and re-run the index command. CI uses a fresh container per run.
 
 ### E2E tests (Playwright)
 
@@ -40,7 +49,7 @@ Browser tests for the shop search page and autocomplete widget live in `tests/Ap
 
 ### Running the test app locally
 
-Serve the app with `symfony serve` from `tests/Application` — not PHP's built-in server (`php -S` can hide real env vars from Symfony Dotenv depending on `variables_order`, so `.env.local` silently wins over exported overrides). `e2e/serve.sh` wraps `symfony serve` for the e2e suite and resolves `MEILISEARCH_SEARCH_KEY` first.
+Serve the app with `symfony serve` from `tests/Application` — not PHP's built-in server (`php -S` can hide real env vars from Symfony Dotenv depending on `variables_order`, so `.env.local` silently wins over exported overrides). Running through the Symfony CLI is also what injects `MEILISEARCH_URL` for the containerized Meilisearch on its random port (see Functional tests above). `e2e/serve.sh` wraps `symfony serve` for the e2e suite; it `eval`s `symfony var:export` so its own health check and `MEILISEARCH_SEARCH_KEY` lookup hit the same instance the app will use (rewriting the CLI's `tcp://` scheme, which curl cannot use).
 
 ### Dependency extremes
 

--- a/README.md
+++ b/README.md
@@ -478,39 +478,46 @@ vendor/bin/rector process --dry-run
 
 ### Running the functional tests
 
-The Functional suite needs MySQL/MariaDB and a Meilisearch instance on `localhost:7700` (master key `aSampleMasterKey`, matching the defaults in `tests/Application/.env`). Start Meilisearch with the bundled compose file:
+The Functional suite needs MySQL/MariaDB and a Meilisearch instance (master key `aSampleMasterKey`, matching the defaults in `tests/Application/.env`). Start Meilisearch with the bundled compose file:
 
 ```shell
 cd tests/Application && docker compose up -d --wait   # `docker compose down` resets it to a clean state
 ```
 
-Without Docker, `tests/Application/meilisearch.sh` downloads and runs the Meilisearch binary instead.
+The compose file binds Meilisearch to a **random host port** so it can never be confused with another Meilisearch running on the standard `7700` — otherwise that instance answers instead, and the suite quietly indexes into and searches it. The [Symfony CLI](https://symfony.com/download) detects the container and injects the resolved `MEILISEARCH_URL` automatically, so run the commands below through it (`symfony console`, and `composer phpunit-functional`, which runs PHPUnit through the CLI from `tests/Application`, where the compose file is). Plain `bin/console`/`vendor/bin/phpunit` fall back to the `localhost:7700` in `tests/Application/.env`, which is what CI and `meilisearch.sh` use.
+
+Without Docker, `tests/Application/meilisearch.sh` downloads and runs the Meilisearch binary on the standard port instead.
 
 Then set up the test application and run the suite:
 
 ```shell
 cd tests/Application
 export APP_ENV=test
-bin/console doctrine:database:create
-bin/console doctrine:schema:create
-bin/console sylius:fixtures:load -n
-bin/console setono:sylius-meilisearch:index --wait
+symfony console doctrine:database:create
+symfony console doctrine:schema:create
+symfony console sylius:fixtures:load -n
+symfony console cache:clear                             # the port changes whenever the container is recreated
+symfony console setono:sylius-meilisearch:index --wait
 cd ../..
-vendor/bin/phpunit --testsuite Functional
+composer phpunit-functional
 ```
+
+> The plugin resolves `MEILISEARCH_URL` when the container is compiled, so after `docker compose up` recreates Meilisearch on a new port, clear the cache — otherwise the app keeps calling the old one (it fails loudly with a connection error).
 
 ### Running the test application in a browser
 
 ```shell
 cd tests/Application
 yarn install && yarn build          # Node 20, see .nvmrc
-bin/console assets:install
-bin/console doctrine:database:create
-bin/console doctrine:schema:create
-bin/console sylius:fixtures:load -n
-bin/console setono:sylius-meilisearch:index --wait
+symfony console assets:install
+symfony console doctrine:database:create
+symfony console doctrine:schema:create
+symfony console sylius:fixtures:load -n
+symfony console setono:sylius-meilisearch:index --wait
 symfony serve
 ```
+
+Use `symfony console` rather than `bin/console`: loading fixtures and indexing both write to Meilisearch, and only the Symfony CLI knows the random port the compose stack is on.
 
 ### Running the end-to-end tests
 
@@ -520,10 +527,11 @@ The Playwright suite drives the shop search page and the autocomplete widget in 
 cd tests/Application
 docker compose up -d --wait
 yarn install && yarn build
-bin/console assets:install                       # APP_ENV=test for all console commands
-bin/console doctrine:database:create && bin/console doctrine:schema:create
-bin/console sylius:fixtures:load -n
-bin/console setono:sylius-meilisearch:index --wait
+symfony console assets:install                   # APP_ENV=test for all console commands
+symfony console doctrine:database:create && symfony console doctrine:schema:create
+symfony console sylius:fixtures:load -n
+symfony console cache:clear
+symfony console setono:sylius-meilisearch:index --wait
 npx playwright install chromium                  # first time only
 yarn e2e                                          # or: yarn e2e:ui
 ```

--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,7 @@
         "check-style": "ecs check",
         "fix-style": "ecs check --fix",
         "phpunit": "phpunit --testsuite Unit",
+        "phpunit-functional": "cd tests/Application && APP_ENV=test symfony php ../../vendor/bin/phpunit -c ../.. --testsuite Functional",
         "rector": "rector"
     }
 }

--- a/tests/Application/compose.yaml
+++ b/tests/Application/compose.yaml
@@ -10,7 +10,12 @@ services:
             MEILI_MASTER_KEY: "aSampleMasterKey" # matches MEILISEARCH_MASTER_KEY in .env
             MEILI_NO_ANALYTICS: "true"
         ports:
-            - "7700:7700"
+            # Random host port on purpose: a fixed 7700 collides with any other Meilisearch you happen
+            # to run (another project's compose stack, a local install), and then this test suite
+            # silently indexes into — and searches — that instance instead of its own.
+            # Run commands through the Symfony CLI (symfony console/php) and it injects the resolved
+            # port as MEILISEARCH_URL, overriding the fallback in .env.
+            - "7700"
         # No volume on purpose: `docker compose down && docker compose up -d` gives a fresh
         # instance, which avoids the stale-document drift you get from a long-lived index.
         # localhost resolves to IPv6 inside the container, but Meilisearch binds IPv4 only, so use 127.0.0.1

--- a/tests/Application/e2e/serve.sh
+++ b/tests/Application/e2e/serve.sh
@@ -10,7 +10,21 @@ set -eu
 # Always run from tests/Application, regardless of the caller's working directory
 cd "$(dirname "$0")/.."
 
-MEILISEARCH_URL="${MEILISEARCH_URL:-http://localhost:7700}"
+# The compose stack binds Meilisearch to a random host port. `symfony serve` resolves it and injects
+# MEILISEARCH_URL into the app on its own, but the health check and the search-key lookup below run in
+# this plain shell, so resolve it here too. Falls back to the standard 7700, which is what CI's service
+# container and meilisearch.sh listen on.
+if command -v symfony >/dev/null 2>&1; then
+    eval "$(symfony var:export 2>/dev/null || true)"
+fi
+
+MEILISEARCH_URL="${MEILISEARCH_URL:-http://127.0.0.1:7700}"
+
+# The Symfony CLI reports the scheme of a Docker service on an unknown port as tcp://. The plugin
+# coerces that to http itself (see normalizeServerUrl), but curl below needs a real URL.
+case "$MEILISEARCH_URL" in
+    tcp://*) MEILISEARCH_URL="http://${MEILISEARCH_URL#tcp://}" ;;
+esac
 MEILISEARCH_MASTER_KEY="${MEILISEARCH_MASTER_KEY:-aSampleMasterKey}"
 PORT="${E2E_PORT:-8080}"
 
@@ -21,6 +35,7 @@ until curl -fsS "$MEILISEARCH_URL/health" >/dev/null 2>&1; do
     if [ "$tries" -gt 30 ]; then
         echo "Meilisearch is not reachable at $MEILISEARCH_URL." >&2
         echo "Start it with: docker compose up -d --wait   (from tests/Application)" >&2
+        echo "If it is running, make sure the Symfony CLI is installed so the random host port can be resolved." >&2
         exit 1
     fi
     sleep 1


### PR DESCRIPTION
## Problem

`tests/Application/compose.yaml` bound Meilisearch to a fixed `7700:7700`. Anything else already listening on 7700 — another project's compose stack, a local install — answers instead, and the test suite silently indexes into and searches **that** instance.

This is not hypothetical: it happened on my machine. The plugin's own compose stack was not even running, and the whole functional suite had been talking to a neighbouring project's Meilisearch, writing `test__products__…` / `test__taxons__…` indexes into it. When that container restarted (no volume), 8 functional tests failed with "Index not found" for reasons that had nothing to do with the code.

## Solution

Bind a **random host port**, so a collision is impossible. That is the whole change — nothing else is needed to resolve the port:

- The Symfony CLI detects the compose service and injects `MEILISEARCH_URL` pointing at the published port, which overrides the fallback in `tests/Application/.env`.
- The CLI reports the scheme as `tcp://` for a Docker service on a port it does not recognise, and `SetonoSyliusMeilisearchExtension::normalizeServerUrl()` already coerces an invalid scheme to `http` — precisely the case its docblock calls out (`e.g. //host or tcp:// are fixed for the user`).

So `.env` is untouched and keeps `localhost:7700` as the fallback for CI's service container and `meilisearch.sh`. **CI needs no changes.**

## What this means for local commands

Commands that talk to Meilisearch must now go through the Symfony CLI (`symfony console`, `symfony php`) — that is what resolves the port. Plain `bin/console` / `vendor/bin/phpunit` fall back to `localhost:7700`.

The CLI matches containers by Docker Compose project name and resolves the project from the **script's** location, so it only finds the stack when the compose file is in scope. `vendor/bin/phpunit` lives at the repo root, so PHPUnit is run from `tests/Application` instead:

```shell
cd tests/Application && symfony php ../../vendor/bin/phpunit -c ../.. --testsuite Functional
```

`composer phpunit-functional` wraps exactly that, and also pins `APP_ENV=test` — under the CLI, `APP_ENV` is pre-set by its own dotenv handling, so PHPUnit's `<env name="APP_ENV">` does not win and `KERNEL_CLASS` would be missing.

Note `sylius:fixtures:load` also writes to Meilisearch (via the Doctrine listener), so it belongs on the `symfony console` list too — the docs now say so.

`e2e/serve.sh` resolves the same URL for its own health check and search-key lookup, rewriting `tcp://` since curl cannot use it.

## Cache caveat

The extension resolves `MEILISEARCH_URL` with `resolveEnvPlaceholders()` at **compile time**, so the URL is baked into the compiled container. Since the port changes whenever the container is recreated, `symfony console cache:clear` is now part of the documented chain. This is pre-existing plugin behaviour, just newly visible. A stale cache fails loudly with a connection error rather than silently using another instance.

## Verification

- Confirmed the app turns the CLI's injected `tcp://127.0.0.1:<port>` into `setono_sylius_meilisearch.server.url = http://127.0.0.1:<port>`, and falls back to `.env` without the CLI.
- **Isolation proof:** with the plugin's own container stopped — and the neighbouring 7700 instance still up — the functional suite errors instead of silently passing against it.
- Full clean-stack run per the documented chain (`docker compose down && up` → `cache:clear` → `index --wait` → `composer phpunit-functional`): 16/16 functional pass.
- Unit 115/115 (unchanged — no test edits needed), ECS, PHPStan (level max), Rector dry-run, `composer validate --strict`, `composer normalize --dry-run` all green. `e2e/serve.sh` syntax-checked and smoke-run.

## Trade-off worth a look

`.env` still falls back to `:7700` when the CLI is not in play, because CI and `meilisearch.sh` legitimately use it. So if you run the suite with the stack **down** and something else is on 7700, you would reach it again — though it can no longer produce false passes, since the plugin's indexes are not written there any more. If you would rather have that be impossible, the alternative is dropping the fallback and setting the host/port explicitly in the CI workflow; happy to switch.