### PR TITLE
Fix ArgumentCountError from ucfirst(...) as choice_label in IndexChoiceType

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
+use Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 
@@ -17,6 +18,12 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->skip([
         __DIR__ . '/tests/Application',
+
+        // A first-class callable to an internal PHP function keeps the function's real arity,
+        // so callbacks invoked with surplus arguments (e.g. Symfony's choice_label calling with
+        // ($choice, $key, $value)) fatal with ArgumentCountError, where a delegating closure
+        // absorbs the extra arguments. This rule caused https://github.com/Setono/sylius-meilisearch-plugin/issues/181
+        ArrowFunctionDelegatingCallToFirstClassCallableRector::class,
     ]);
 
     $rectorConfig->sets([

--- a/src/Form/Type/IndexChoiceType.php
+++ b/src/Form/Type/IndexChoiceType.php
@@ -21,7 +21,10 @@ final class IndexChoiceType extends AbstractType
 
         $resolver->setDefaults([
             'choices' => array_combine($names, $names),
-            'choice_label' => ucfirst(...),
+            // not ucfirst(...): choice_label is called with ($choice, $key, $value), and a
+            // first-class callable to an internal function throws ArgumentCountError on the
+            // surplus arguments, where a closure absorbs them
+            'choice_label' => static fn (string $name): string => ucfirst($name),
         ]);
     }
 

--- a/tests/Unit/Form/Type/IndexChoiceTypeTest.php
+++ b/tests/Unit/Form/Type/IndexChoiceTypeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Form\Type;
+
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusMeilisearchPlugin\Config\IndexRegistryInterface;
+use Setono\SyliusMeilisearchPlugin\Form\Type\IndexChoiceType;
+use Symfony\Component\Form\ChoiceList\View\ChoiceView;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Form\Type\IndexChoiceType
+ */
+final class IndexChoiceTypeTest extends TypeTestCase
+{
+    use ProphecyTrait;
+
+    protected function getExtensions(): array
+    {
+        $indexRegistry = $this->prophesize(IndexRegistryInterface::class);
+        $indexRegistry->getNames()->willReturn(['products', 'taxons']);
+
+        return [
+            new PreloadedExtension([new IndexChoiceType($indexRegistry->reveal())], []),
+        ];
+    }
+
+    /**
+     * The choice_label callable is only invoked (with three arguments) when the choice list
+     * view is built, so createView() is required to cover the admin rendering path.
+     *
+     * @test
+     */
+    public function it_builds_a_form_view_with_capitalized_labels(): void
+    {
+        $view = $this->factory->create(IndexChoiceType::class)->createView();
+
+        $vars = $view->vars;
+        self::assertIsArray($vars);
+        self::assertArrayHasKey('choices', $vars);
+        self::assertIsArray($vars['choices']);
+
+        $labels = [];
+        foreach ($vars['choices'] as $choice) {
+            self::assertInstanceOf(ChoiceView::class, $choice);
+            self::assertIsString($choice->label);
+            $labels[] = $choice->label;
+        }
+
+        self::assertSame(['Products', 'Taxons'], $labels);
+    }
+}


### PR DESCRIPTION
Fixes #181

## Problem

`IndexChoiceType` used `ucfirst(...)` as `choice_label`. Symfony invokes that callable with three arguments (`$choice`, `$key`, `$value`), and a first-class callable to an **internal** PHP function keeps the function's real arity — so building the choice list view throws `ArgumentCountError`, fataling every admin page that renders the type (the synonym grid's `indexes` filter and the synonym create/edit form).

## Root cause

The regression came from Rector: `ArrowFunctionDelegatingCallToFirstClassCallableRector` rewrote the original (working) delegating closure into `ucfirst(...)` during the Sylius 1.14 migration. Restoring the closure alone would not stick — the next `rector process` run would reintroduce the bug.

## Changes

- Restore the delegating closure in `IndexChoiceType`, with a comment explaining why a first-class callable must not be used here.
- Skip `ArrowFunctionDelegatingCallToFirstClassCallableRector` in `rector.php` — the transformation is unsafe whenever the delegated-to function is internal and the callback is invoked with surplus arguments.
- Add `IndexChoiceTypeTest`, which builds the **form view** (not just the form) through the real Symfony Form stack — the error only triggers at `buildView()` time. The test reproduces the exact stack trace from the issue before the fix and passes after.

## Verification

- New test red on the previous code (`ArgumentCountError` in `DefaultChoiceListFactory.php:162`), green after the fix
- `composer analyse` clean, `composer check-style` clean, `vendor/bin/rector process --dry-run` clean
- Full Unit suite: 116 tests, 236 assertions, OK
- `bin/console lint:container` (test app) passes