### PR TITLE
Return a 404 for an unknown taxon slug

### DIFF
--- a/src/EventSubscriber/Search/TaxonSearchSubscriber.php
+++ b/src/EventSubscriber/Search/TaxonSearchSubscriber.php
@@ -11,6 +11,7 @@ use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Contracts\Service\ResetInterface;
 
 final class TaxonSearchSubscriber implements EventSubscriberInterface, ResetInterface
@@ -48,6 +49,11 @@ final class TaxonSearchSubscriber implements EventSubscriberInterface, ResetInte
         }
 
         $this->taxon = $this->taxonRepository->findOneBySlug($slug, $this->localeContext->getLocaleCode());
+        if (null === $this->taxon) {
+            // Without this, an unknown slug would silently drop the taxon filter and render the
+            // whole catalog with a 200 — Sylius' own taxon page (and search engines) expect a 404.
+            throw new NotFoundHttpException(sprintf('Taxon with slug "%s" does not exist', $slug));
+        }
     }
 
     public function updateFilters(SearchFiltersBuilt $event): void

--- a/tests/Unit/EventSubscriber/Search/TaxonSearchSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/Search/TaxonSearchSubscriberTest.php
@@ -16,6 +16,7 @@ use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @covers \Setono\SyliusMeilisearchPlugin\EventSubscriber\Search\TaxonSearchSubscriber
@@ -92,6 +93,27 @@ final class TaxonSearchSubscriberTest extends TestCase
         $filtersBuilt = new SearchFiltersBuilt([]);
         $subscriber->updateFilters($filtersBuilt);
         self::assertSame([], $filtersBuilt->filters);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_a_not_found_exception_for_an_unknown_slug(): void
+    {
+        $localeContext = $this->prophesize(LocaleContextInterface::class);
+        $localeContext->getLocaleCode()->willReturn('en_US');
+
+        $taxonRepository = $this->prophesize(TaxonRepositoryInterface::class);
+        $taxonRepository->findOneBySlug('does-not-exist', 'en_US')->willReturn(null);
+
+        $subscriber = new TaxonSearchSubscriber($taxonRepository->reveal(), $localeContext->reveal());
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $subscriber->setTaxon($this->createSearchRequestCreated([
+            '_route' => 'sylius_shop_product_index',
+            'slug' => 'does-not-exist',
+        ]));
     }
 
     /**


### PR DESCRIPTION
`TaxonSearchSubscriber` silently dropped the taxon filter when the slug matched no taxon, so any made-up `/t/{slug}` URL rendered the whole catalog with a 200. Sylius' own taxon page (and search engines) expect a 404 there.