### PR TITLE
Filter on int facets

### DIFF
--- a/src/Meilisearch/Filter/IntFilterBuilder.php
+++ b/src/Meilisearch/Filter/IntFilterBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Meilisearch\Filter;
+
+final class IntFilterBuilder implements FilterBuilderInterface
+{
+    public function build(array $facets, array $facetsValues): array
+    {
+        $filters = [];
+
+        foreach ($facets as $facet) {
+            if ($facet->type === 'int' && isset($facetsValues[$facet->name])) {
+                /** @var mixed $values */
+                $values = $facetsValues[$facet->name];
+                if (!is_array($values)) {
+                    continue;
+                }
+
+                if (isset($values['min']) && '' !== $values['min'] && is_numeric($values['min'])) {
+                    $filters[] = $facet->name . '>=' . $values['min'];
+                }
+                if (isset($values['max']) && '' !== $values['max'] && is_numeric($values['max'])) {
+                    $filters[] = $facet->name . '<=' . $values['max'];
+                }
+            }
+        }
+
+        return $filters;
+    }
+}

--- a/src/Resources/config/services/filter.xml
+++ b/src/Resources/config/services/filter.xml
@@ -23,5 +23,9 @@
         <service id="Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\FloatFilterBuilder">
             <tag name="setono_sylius_meilisearch.filter_builder" />
         </service>
+
+        <service id="Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\IntFilterBuilder">
+            <tag name="setono_sylius_meilisearch.filter_builder" />
+        </service>
     </services>
 </container>

--- a/tests/Unit/Meilisearch/Builder/IntFilterBuilderTest.php
+++ b/tests/Unit/Meilisearch/Builder/IntFilterBuilderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusMeilisearchPlugin\Tests\Unit\Meilisearch\Builder;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusMeilisearchPlugin\Document\Metadata\Facet;
+use Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\IntFilterBuilder;
+
+/**
+ * @covers \Setono\SyliusMeilisearchPlugin\Meilisearch\Filter\IntFilterBuilder
+ */
+final class IntFilterBuilderTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_builds_range_filter_expressions_for_int_facets(): void
+    {
+        $builder = new IntFilterBuilder();
+
+        $filters = $builder->build(
+            ['lumen' => new Facet('lumen', 'int')],
+            ['lumen' => ['min' => '1000', 'max' => '3000']],
+        );
+
+        self::assertSame(['lumen>=1000', 'lumen<=3000'], $filters);
+    }
+
+    /**
+     * @test
+     */
+    public function it_builds_a_single_bound(): void
+    {
+        $builder = new IntFilterBuilder();
+
+        $filters = $builder->build(
+            ['lumen' => new Facet('lumen', 'int')],
+            ['lumen' => ['min' => '', 'max' => '3000']],
+        );
+
+        self::assertSame(['lumen<=3000'], $filters);
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_other_facet_types_and_non_numeric_values(): void
+    {
+        $builder = new IntFilterBuilder();
+
+        $filters = $builder->build(
+            [
+                'price' => new Facet('price', 'float'),
+                'lumen' => new Facet('lumen', 'int'),
+            ],
+            [
+                'price' => ['min' => '10'],
+                'lumen' => ['min' => 'abc', 'max' => '3000; DROP'],
+            ],
+        );
+
+        self::assertSame([], $filters);
+    }
+}


### PR DESCRIPTION
`RangeFilterFormBuilder` renders the min/max widget for both `float` and `int` facets, but only a `FloatFilterBuilder` existed — an integer range was displayed, accepted and then silently ignored. This adds the `int` counterpart, registered like the other filter builders.